### PR TITLE
fix: Remove run start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-npm run start || exit 1
+node dist/index.js || exit 1

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "tslint -p tsconfig.json --fix",
     "build": "tsc -p tsconfig.json",
     "watch:build": "tsc -p tsconfig.json --watch",
-    "start": "npm run build && node ./dist",
+    "start": "ts-node src/index.ts",
     "debug": "npm run build && node --inspect ./dist",
     "start:watch": "nodemon src/index.ts",
     "migrate": "ts-node migrations/index.ts",


### PR DESCRIPTION
This PR removes the `npm run start` from the image that contained a build procedure.