### PR TITLE
fix: Add fixes to the estate data and name

### DIFF
--- a/src/ports/browse/sources/marketplace.spec.ts
+++ b/src/ports/browse/sources/marketplace.spec.ts
@@ -32,21 +32,63 @@ describe('when building a result from the marketplace fragment', () => {
     beforeEach(() => {
       marketplaceFragment.parcel!.estate = {
         tokenId: 'string',
-        data: {
-          name: 'name',
-        },
+        data: null
       }
     })
 
-    it('should return a result containing a parcel with the estate', () => {
-      const result = fromMarketplaceFragment(marketplaceFragment)
-      const parcelEstate = result.nft.data.parcel!.estate
+    describe("with a estate that contains data", () => {
+      describe("without a null name", () => {
+        beforeEach(() => {
+          marketplaceFragment.parcel!.estate!.data = {
+            name: 'name',
+          }
+        });
 
-      expect(parcelEstate).toEqual({
-        tokenId: marketplaceFragment.parcel!.estate?.tokenId,
-        name: marketplaceFragment.parcel!.estate?.data.name,
+        it('should return a result containing a parcel with the estate, containing its name', () => {
+          const result = fromMarketplaceFragment(marketplaceFragment)
+          const parcelEstate = result.nft.data.parcel!.estate
+    
+          expect(parcelEstate).toEqual({
+            tokenId: marketplaceFragment.parcel!.estate!.tokenId,
+            name: marketplaceFragment.parcel!.estate!.data!.name,
+          })
+        })
       })
-    })
+
+      describe("with a null name", () => {
+        beforeEach(() => {
+          marketplaceFragment.parcel!.estate!.data = {
+            name: null,
+          }
+        });
+
+        it('should return a result containing a parcel with the estate, having its name as "Estate"', () => {
+          const result = fromMarketplaceFragment(marketplaceFragment)
+          const parcelEstate = result.nft.data.parcel!.estate
+    
+          expect(parcelEstate).toEqual({
+            tokenId: marketplaceFragment.parcel!.estate!.tokenId,
+            name: "Estate",
+          })
+        })
+      });
+    });
+
+    describe("with a estate that doesn't contain data", () => {
+      beforeEach(() => {
+        marketplaceFragment.parcel!.estate!.data = null;
+      });
+      
+      it('should return a result containing a parcel with the estate, having its name as "Estate"', () => {
+        const result = fromMarketplaceFragment(marketplaceFragment)
+        const parcelEstate = result.nft.data.parcel!.estate
+  
+        expect(parcelEstate).toEqual({
+          tokenId: marketplaceFragment.parcel!.estate!.tokenId,
+          name: "Estate",
+        })
+      })
+    });
   })
 
   describe("with a parcel that doesn't belong to an estate", () => {

--- a/src/ports/browse/sources/marketplace.ts
+++ b/src/ports/browse/sources/marketplace.ts
@@ -18,6 +18,8 @@ import {
 } from '../../source/utils'
 import { isExpired } from '../utils'
 
+const PARCEL_ESTATE_NAME_DEFAULT_VALUE = 'Estate'
+
 export const getMarketplaceChainId = () =>
   parseInt(
     process.env.MARKETPLACE_CHAIN_ID || ChainId.ETHEREUM_MAINNET.toString()
@@ -95,10 +97,10 @@ export type MarketplaceFields = Omit<
       description: string
     } | null
     estate: {
-      tokenId: string,
+      tokenId: string
       data: {
-        name: string
-      }
+        name: string | null
+      } | null
     } | null
   }
   estate?: {
@@ -158,10 +160,15 @@ export function fromMarketplaceFragment(fragment: MarketplaceFragment): Result {
                 null,
               x: fragment.parcel.x,
               y: fragment.parcel.y,
-              estate: fragment.parcel.estate ? {
-                tokenId: fragment.parcel.estate.tokenId,
-                name: fragment.parcel.estate.data.name
-              } : null
+              estate: fragment.parcel.estate
+                ? {
+                    tokenId: fragment.parcel.estate.tokenId,
+                    name: fragment.parcel.estate.data
+                      ? fragment.parcel.estate.data.name ??
+                        PARCEL_ESTATE_NAME_DEFAULT_VALUE
+                      : PARCEL_ESTATE_NAME_DEFAULT_VALUE,
+                  }
+                : null,
             }
           : undefined,
         estate: fragment.estate


### PR DESCRIPTION
This PR defines a default value for the estate name when there's no data about it or the name of the estate is null.