### PR TITLE
fix: items

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ type NFT = {
 - `isWearableHead`: Only return results that their category is `wearable` and are part of the avatar's head. Type `boolean`.
 - `isWearableAccessory`: Only return results that their category is `wearable` and accessories (not a part of the body).
 - `wearableCategory`: Filter results by `WearableCategory`. Possible values: `eyebrows`,`eyes`,`facial_hair`,`hair`,`mouth`,`upper_body`,`lower_body`,`feet`,`earring`,`eyewear`,`hat`,`helmet`,`mask`,`tiara`,`top_head`.
-- `wearableRarity`: Filter results by `WearableRarity`. It supports multiple values by adding the query param multiple times. Possible values: `unique`, `mythic`, `legendary`, `epic`, `rare`, `uncommon`, `common`.
 - `wearableGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
 - `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `tokenId`: Filter results by `tokenId`. Type: `string`.
+- `itemRarity`: Filter results by `Rarity`. It supports multiple values by adding the query param multiple times. Possible values: `unique`, `mythic`, `legendary`, `epic`, `rare`, `uncommon`, `common`.
 - `itemId`: Filter results by `itemId`. Type `string`.
 - `network`: Filter results by `Network`. Possible values: `ETHEREUM`, `MATIC`.
 
@@ -80,7 +80,7 @@ type Item = {
   category: NFTCategory
   contractAddress: string
   itemId: string
-  rarity: WearableRarity
+  rarity: Rarity
   price: string
   available: number
   creator: string
@@ -98,13 +98,13 @@ type Item = {
 - `skip`: Skip results. Type: `number`.
 - `sortBy`: Sort results. Possible values: `newest`, `name`, `cheapest`.
 - `creator`: Filter by creator. Type: `address`.
+- `rarity`: Filter results by `Rarity`. It supports multiple values by adding the query param multiple times. Possible values: `unique`, `mythic`, `legendary`, `epic`, `rare`, `uncommon`, `common`.
 - `isSoldOut`: Only return results that are sold out (all NFTs have been minted). Type: `boolean`.
 - `isOnSale`: Only return results that can be bought (`CollectionStore` has been added as minter, and there's still available supply to mint). Type: `boolean`.
 - `search`: Free text search. Type: `string`.
 - `isWearableHead`: Only return results that their category is `wearable` and are part of the avatar's head. Type `boolean`.
 - `isWearableAccessory`: Only return results that their category is `wearable` and accessories (not a part of the body).
 - `wearableCategory`: Filter results by `WearableCategory`. Possible values: `eyebrows`,`eyes`,`facial_hair`,`hair`,`mouth`,`upper_body`,`lower_body`,`feet`,`earring`,`eyewear`,`hat`,`helmet`,`mask`,`tiara`,`top_head`.
-- `wearableRarity`: Filter results by `WearableRarity`. It supports multiple values by adding the query param multiple times. Possible values: `unique`, `mythic`, `legendary`, `epic`, `rare`, `uncommon`, `common`.
 - `wearableGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
 - `contractAddress`: Filter results by contract address. Type: `address`.
 - `itemId`: Filter results by `itemId`. Type: `string`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^1.3.0",
+        "@dcl/schemas": "^1.4.0",
         "@types/sqlite3": "^3.1.7",
         "@well-known-components/env-config-provider": "^1.0.0",
         "@well-known-components/http-server": "^1.0.0",
@@ -677,9 +677,9 @@
       "dev": true
     },
     "node_modules/@dcl/schemas": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.3.0.tgz",
-      "integrity": "sha512-hsePfJjuWqT8AgXhCNEtZvm/bd3Z7paM9+QARIP9wfa4UmO/oi3aCzh0+vqg67r8clc0zdHYozPsSelyQV34vg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.4.0.tgz",
+      "integrity": "sha512-/8ylLILd9tz39wV4+B/6DrH+PASMaWHfmi42s8wj0H6RNeZ1zr/6Stu2z1oLhX5kZ/DDkA0z9InktWxZCLJa9w==",
       "dependencies": {
         "ajv": "^7.1.0"
       }
@@ -10078,9 +10078,9 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.3.0.tgz",
-      "integrity": "sha512-hsePfJjuWqT8AgXhCNEtZvm/bd3Z7paM9+QARIP9wfa4UmO/oi3aCzh0+vqg67r8clc0zdHYozPsSelyQV34vg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.4.0.tgz",
+      "integrity": "sha512-/8ylLILd9tz39wV4+B/6DrH+PASMaWHfmi42s8wj0H6RNeZ1zr/6Stu2z1oLhX5kZ/DDkA0z9InktWxZCLJa9w==",
       "requires": {
         "ajv": "^7.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "printWidth": 80
   },
   "dependencies": {
-    "@dcl/schemas": "^1.3.0",
+    "@dcl/schemas": "^1.4.0",
     "@types/sqlite3": "^3.1.7",
     "@well-known-components/env-config-provider": "^1.0.0",
     "@well-known-components/http-server": "^1.0.0",

--- a/src/adapters/handlers/items.ts
+++ b/src/adapters/handlers/items.ts
@@ -26,7 +26,7 @@ export function createItemsHandler(
       'wearableCategory',
       WearableCategory
     )
-    const wearableRarities = params.getList<Rarity>('wearableRarity', Rarity)
+    const rarities = params.getList<Rarity>('rarity', Rarity)
     const wearableGenders = params.getList<WearableGender>(
       'wearableGender',
       WearableGender
@@ -41,13 +41,13 @@ export function createItemsHandler(
         skip,
         sortBy,
         creator,
+        rarities,
         isSoldOut,
         isOnSale,
         search,
         isWearableHead,
         isWearableAccessory,
         wearableCategory,
-        wearableRarities,
         wearableGenders,
         contractAddress,
         itemId,

--- a/src/adapters/handlers/nfts.ts
+++ b/src/adapters/handlers/nfts.ts
@@ -26,13 +26,13 @@ export function createNFTsHandler(
       'wearableCategory',
       WearableCategory
     )
-    const wearableRarities = params.getList<Rarity>('wearableRarity', Rarity)
     const wearableGenders = params.getList<WearableGender>(
       'wearableGender',
       WearableGender
     )
     const contractAddresses = params.getAddressList('contractAddress')
     const tokenId = params.getString('tokenId')
+    const itemRarities = params.getList<Rarity>('itemRarity', Rarity)
     const itemId = params.getString('itemId')
     const network = params.getValue<Network>('network', Network)
 
@@ -49,10 +49,10 @@ export function createNFTsHandler(
         isWearableHead,
         isWearableAccessory,
         wearableCategory,
-        wearableRarities,
         wearableGenders,
         contractAddresses,
         tokenId,
+        itemRarities,
         itemId,
         network,
       })

--- a/src/ports/items/types.ts
+++ b/src/ports/items/types.ts
@@ -43,8 +43,6 @@ export type ItemFragment = {
   collection: {
     id: string
     creator: string
-    createdAt: string
-    updatedAt: string
   }
   metadata: {
     wearable: {
@@ -54,6 +52,8 @@ export type ItemFragment = {
     }
   }
   searchWearableBodyShapes: BodyShape[]
+  createdAt: string
+  updatedAt: string
 }
 
 export interface IItemsComponent {

--- a/src/ports/items/types.ts
+++ b/src/ports/items/types.ts
@@ -52,6 +52,7 @@ export type ItemFragment = {
     }
   }
   searchWearableBodyShapes: BodyShape[]
+  searchIsStoreMinter: boolean
   createdAt: string
   updatedAt: string
 }

--- a/src/ports/items/types.ts
+++ b/src/ports/items/types.ts
@@ -14,13 +14,13 @@ export type ItemFilters = {
   skip?: number
   sortBy?: ItemSortBy
   creator?: string
+  rarities?: Rarity[]
   isSoldOut?: boolean
   isOnSale?: boolean
   search?: string
   isWearableHead?: boolean
   isWearableAccessory?: boolean
   wearableCategory?: WearableCategory
-  wearableRarities?: Rarity[]
   wearableGenders?: WearableGender[]
   contractAddress?: string
   itemId?: string

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -31,8 +31,8 @@ export function fromItemFragment(
     },
     network,
     chainId,
-    createdAt: +fragment.collection.createdAt * 1000,
-    updatedAt: +fragment.collection.updatedAt * 1000,
+    createdAt: +fragment.createdAt * 1000,
+    updatedAt: +fragment.updatedAt * 1000,
   }
 
   return item
@@ -49,8 +49,6 @@ export const getItemFragment = () => `
     collection {
       id
       creator
-      createdAt
-      updatedAt
     }
     metadata {
       wearable {
@@ -60,6 +58,8 @@ export const getItemFragment = () => `
       }
     }
     searchWearableBodyShapes
+    createdAt
+    updatedAt
   }
 `
 
@@ -162,8 +162,8 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
   let orderDirection: string
   switch (sortBy || ITEM_DEFAULT_SORT_BY) {
     case ItemSortBy.NEWEST:
-      orderBy = ''
-      orderDirection = ''
+      orderBy = 'createdAt'
+      orderDirection = 'desc'
       break
     case ItemSortBy.NAME:
       orderBy = 'searchText'
@@ -174,8 +174,8 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
       orderDirection = 'asc'
       break
     default:
-      orderBy = ''
-      orderDirection = ''
+      orderBy = 'createdAt'
+      orderDirection = 'desc'
   }
 
   const query = `query Items {

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -20,6 +20,7 @@ export function fromItemFragment(
     rarity: fragment.rarity,
     price: fragment.price,
     available: +fragment.available,
+    isOnSale: fragment.searchIsStoreMinter && +fragment.available > 0,
     creator: fragment.collection.creator,
     data: {
       wearable: {
@@ -58,6 +59,7 @@ export const getItemFragment = () => `
       }
     }
     searchWearableBodyShapes
+    searchIsStoreMinter
     createdAt
     updatedAt
   }

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -69,13 +69,13 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     skip,
     sortBy,
     creator,
+    rarities,
     isSoldOut,
     isOnSale,
     search,
     isWearableHead,
     isWearableAccessory,
     wearableCategory,
-    wearableRarities,
     wearableGenders,
     contractAddress,
     itemId,
@@ -115,9 +115,9 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     where.push('searchIsWearableAccessory: true')
   }
 
-  if (wearableRarities && wearableRarities.length > 0) {
+  if (rarities && rarities.length > 0) {
     where.push(
-      `searchWearableRarity_in: [${wearableRarities
+      `searchWearableRarity_in: [${rarities
         .map((rarity) => `"${rarity}"`)
         .join(',')}]`
     )

--- a/src/ports/nfts/types.ts
+++ b/src/ports/nfts/types.ts
@@ -20,11 +20,11 @@ export type NFTFilters = {
   owner?: string
   isOnSale?: boolean
   search?: string
+  itemRarities?: Rarity[]
   isLand?: boolean
   isWearableHead?: boolean
   isWearableAccessory?: boolean
   wearableCategory?: WearableCategory
-  wearableRarities?: Rarity[]
   wearableGenders?: WearableGender[]
   contractAddresses?: string[]
   tokenId?: string

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -88,9 +88,9 @@ export function getFetchQuery(
     where.push('searchIsWearableAccessory: $isWearableAccessory')
   }
 
-  if (filters.wearableRarities && filters.wearableRarities.length > 0) {
+  if (filters.itemRarities && filters.itemRarities.length > 0) {
     where.push(
-      `searchWearableRarity_in: [${filters.wearableRarities
+      `searchWearableRarity_in: [${filters.itemRarities
         .map((rarity) => `"${rarity}"`)
         .join(',')}]`
     )


### PR DESCRIPTION
- On the NFT level renamed `wearableRarity` to `itemRarity`, so the wearable only properties are prefixed with `wearable` (like `wearableGender` and `wearableCategory`) and the item only properties are prefixed with `item` (like `itemRarity` and `itemId`).

- On the item level, it is just `rarity` instead of `wearableRarity`

- Fixed bug in item pagination using now `createdAt` to sort results.

- Added `isOnSale` property to items (which is `true` if the store has been added as minter and the max supply has not been reached)