### PR TITLE
chore: Increase instances count

### DIFF
--- a/.ci/index.ts
+++ b/.ci/index.ts
@@ -64,6 +64,8 @@ export = async function main() {
       },
       version: '1',
       memoryReservation: 1024,
+      cpuReservation: 256,
+      desiredCount: env === 'prd' ? 3 : 1,
       extraExposedServiceOptions: {
         createCloudflareProxiedSubdomain: true,
       },


### PR DESCRIPTION
This PR increases the instances of the service in production from 1 to 3. It also sets the cpuReservation variable to 256, the default value that it had before, but makes it visible.