### PR TITLE
feat: Add request logger middleware

### DIFF
--- a/src/adapters/routes.ts
+++ b/src/adapters/routes.ts
@@ -8,6 +8,7 @@ import { createItemsHandler } from './handlers/items'
 import { createMintsHandler } from './handlers/mints'
 import { createSalesHandler } from './handlers/sales'
 import { createCollectionsHandler } from './handlers/collections'
+import { createRequestLoggerMiddleware } from '../logic/request-logger-middleware'
 
 export async function setupRoutes(globalContext: GlobalContext) {
   const { components } = globalContext
@@ -17,7 +18,11 @@ export async function setupRoutes(globalContext: GlobalContext) {
 
   const apiVersion = await config.requireString('API_VERSION')
 
+  
+
   router.prefix(`/${apiVersion}`)
+  
+  router.use(createRequestLoggerMiddleware(components))
 
   router.get('/bids', createBidsHandler(components))
   router.get('/orders', createOrdersHandler(components))

--- a/src/adapters/routes.ts
+++ b/src/adapters/routes.ts
@@ -18,10 +18,8 @@ export async function setupRoutes(globalContext: GlobalContext) {
 
   const apiVersion = await config.requireString('API_VERSION')
 
-  
-
   router.prefix(`/${apiVersion}`)
-  
+
   router.use(createRequestLoggerMiddleware(components))
 
   router.get('/bids', createBidsHandler(components))

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,9 @@ async function initComponents(): Promise<AppComponents> {
   }
 
   const logs = createLogComponent()
+
+  const globalLogger = logs.getLogger('nft-server')
+
   const server = await createServerComponent<GlobalContext>(
     { config, logs },
     { cors, compression: {} }
@@ -342,6 +345,7 @@ async function initComponents(): Promise<AppComponents> {
   return {
     config,
     logs,
+    globalLogger,
     server,
     statusChecks,
     metrics,

--- a/src/logic/request-logger-middleware.ts
+++ b/src/logic/request-logger-middleware.ts
@@ -66,6 +66,7 @@ export function createRequestLoggerMiddleware(
           message: error.message,
         })
       )
+      
       return {
         status: 500,
         body: error.message,

--- a/src/logic/request-logger-middleware.ts
+++ b/src/logic/request-logger-middleware.ts
@@ -1,0 +1,80 @@
+import {
+  IHttpServerComponent,
+  ILoggerComponent,
+} from '@well-known-components/interfaces'
+import { AppComponents, Context } from '../types'
+
+enum RequestState {
+  REQUEST = 'REQUEST',
+  SUCCESS = 'SUCCESS',
+  FAILURE = 'FAILURE',
+  UNKNOWN = 'UNKNOWN',
+}
+
+export function createRequestLoggerMiddleware(
+  components: Pick<AppComponents, 'globalLogger'>
+): IHttpServerComponent.IRequestHandler<Context<string>> {
+  const { globalLogger: logger } = components
+
+  return async (context, next) => {
+    const url = context.url.toString()
+    const start = Date.now()
+    const id = start
+
+    logger.info(
+      url,
+      buildLogData({
+        id,
+        state: RequestState.REQUEST,
+      })
+    )
+
+    const result = await next()
+    const status = result.status
+    const finish = Date.now()
+
+    logger.info(
+      url,
+      buildLogData({
+        id,
+        state: status
+          ? status < 400
+            ? RequestState.SUCCESS
+            : RequestState.FAILURE
+          : RequestState.UNKNOWN,
+        code: status,
+        time: finish - start,
+      })
+    )
+
+    return result
+  }
+}
+
+function buildLogData({
+  id,
+  state,
+  code,
+  time,
+}: {
+  id: number
+  state: RequestState
+  code?: number
+  time?: number
+  message?: string
+}) {
+  const data: Parameters<ILoggerComponent.ILogger['info']>[1] = {
+    id,
+    state,
+  }
+
+  if (code) {
+    data.code = code
+  }
+
+  if (time) {
+    data.time = time
+  }
+
+  return data
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export type GlobalContext = {
 export type AppComponents = {
   config: IConfigComponent
   logs: ILoggerComponent
+  globalLogger: ILoggerComponent.ILogger
   server: IHttpServerComponent<GlobalContext>
   statusChecks: IBaseComponent
   metrics: IMetricsComponent<any>


### PR DESCRIPTION
Log all incoming requests displaying:

- id: For tracing request and response
- state: State of the request, REQUEST for when the request is received, SUCCESS when there is a successful response, FAILURE for the contrary, UNHANDLED_FAILURE when the request fails without being handled correctly and UNKOWN where there is a response without status code (I have no clue when that could happen but better safe than sorry)
- code: Status code of the response
- time: Time taken between the start of the request and the response
- message: Currently used to display the error of >= 500 responses and UNHANDLED_FAILUREs

```
2021-11-18T17:03:13.083Z [INFO] (nft-server): http://localhost:5000/v1/nfts?foo=bar     {"id":1637254993083,"state":"REQUEST"}
2021-11-18T17:03:14.044Z [INFO] (nft-server): http://localhost:5000/v1/nfts?foo=bar     {"id":1637254993083,"state":"SUCCESS","code":200,"time":961}
```