### PR TITLE
feat: Add accounts endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,33 @@ export type Sale = {
 - `maxPrice`: Return only sales with a price lower than this. Type `number`.
 - `network`: Filter results by `Network`. Possible values: `ETHEREUM`, `MATIC`.
 
+## Accounts
+
+**Endpoint**: `/v1/accounts`
+
+**Type**:
+
+```ts
+export type Account = {
+  id: string
+  address: string
+  sales: number
+  purchases: number
+  spent: string
+  earned: string
+  royalties: string
+}
+```
+
+**Query Params**:
+
+- `first`: Limit the number of results. Type: `number`.
+- `skip`: Skip results. Type: `number`.
+- `sortBy`: Sort results. Possible values: `most_sales`, `most_purchases`, `most_spent`, `most_earned`, `most_royalties`.
+- `id`: Filter by user address. Type: `string`.
+- `address`: Currently the same as id, Filter by user address. Type: 'string'.
+- `network`: Filter results by `Network`. Possible values: `ETHEREUM`, `MATIC`.
+
 ## Collections
 
 **Endpoint**: `/v1/collections`

--- a/package-lock.json
+++ b/package-lock.json
@@ -533,9 +533,9 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.0.0.tgz",
-      "integrity": "sha512-9hs+Vafs9D3X/lYjLnPTXQ1BCcZTUExNhH9aIAbt7LlwXFxN5xvmhFDvEcBZ6KLRgc8SA2lR2Z9KpHalrNk1Uw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.1.1.tgz",
+      "integrity": "sha512-LsNpyjf6T8OM8FkuHrzO2vPoSAggBj1iKY3myoH5K+YYM1s4xBD6wZK9JTcXa9dhBfPnlrr7aJWIsJ81oztlIQ==",
       "requires": {
         "ajv": "^7.1.0"
       }
@@ -1690,7 +1690,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true
     },
     "async-listener": {
       "version": "0.6.10",
@@ -2906,7 +2907,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -3027,6 +3029,7 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -5667,7 +5670,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
     },
     "jsdom": {
       "version": "16.7.0",
@@ -7418,7 +7422,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "printWidth": 80
   },
   "dependencies": {
-    "@dcl/schemas": "^3.0.0",
+    "@dcl/schemas": "^3.1.1",
     "@types/sqlite3": "^3.1.7",
     "@well-known-components/env-config-provider": "^1.0.0",
     "@well-known-components/http-server": "^1.0.0",

--- a/src/adapters/handlers/accounts.ts
+++ b/src/adapters/handlers/accounts.ts
@@ -1,0 +1,33 @@
+import { AccountSortBy, Network } from '@dcl/schemas'
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { Params } from '../../logic/http/params'
+import { asJSON } from '../../logic/http/response'
+import { AppComponents, Context } from '../../types'
+
+export function createAccountsHandler(
+  components: Pick<AppComponents, 'logs' | 'accounts'>
+): IHttpServerComponent.IRequestHandler<Context<'/accounts'>> {
+  const { accounts } = components
+
+  return async (context) => {
+    const params = new Params(context.url.searchParams)
+
+    const first = params.getNumber('first')
+    const skip = params.getNumber('skip')
+    const sortBy = params.getValue<AccountSortBy>('sortBy', AccountSortBy)
+    const id = params.getString('id')
+    const address = params.getString('address')
+    const network = params.getValue<Network>('network', Network)
+
+    return asJSON(() =>
+      accounts.fetchAndCount({
+        first,
+        skip,
+        sortBy,
+        id,
+        address,
+        network,
+      })
+    )
+  }
+}

--- a/src/adapters/routes.ts
+++ b/src/adapters/routes.ts
@@ -9,6 +9,7 @@ import { createMintsHandler } from './handlers/mints'
 import { createSalesHandler } from './handlers/sales'
 import { createCollectionsHandler } from './handlers/collections'
 import { createRequestLoggerMiddleware } from '../logic/requestLoggerMiddleware'
+import { createAccountsHandler } from './handlers/accounts'
 
 export async function setupRoutes(globalContext: GlobalContext) {
   const { components } = globalContext
@@ -31,6 +32,7 @@ export async function setupRoutes(globalContext: GlobalContext) {
   router.get('/mints', createMintsHandler(components))
   router.get('/sales', createSalesHandler(components))
   router.get('/collections', createCollectionsHandler(components))
+  router.get('/accounts', createAccountsHandler(components))
   router.get(
     '/contracts/:contractAddress/tokens/:tokenId',
     createNFTHandler(components)

--- a/src/adapters/sources/accounts.ts
+++ b/src/adapters/sources/accounts.ts
@@ -1,0 +1,31 @@
+import { Account, AccountFilters, AccountSortBy } from '@dcl/schemas'
+import { IAccountsComponent } from '../../ports/accounts/types'
+import { FetchOptions, IMergerComponent } from '../../ports/merger/types'
+
+export function createAccountsSource(
+  accounts: IAccountsComponent
+): IMergerComponent.Source<Account, AccountFilters, AccountSortBy> {
+  async function fetch(filters: FetchOptions<AccountFilters, AccountSortBy>) {
+    const results = await accounts.fetch(filters)
+    return results.map((result) => ({
+      result,
+      sort: {
+        [AccountSortBy.MOST_SPENT]: result.spent,
+        [AccountSortBy.MOST_EARNED]: result.earned,
+        [AccountSortBy.MOST_PURCHASES]: result.purchases,
+        [AccountSortBy.MOST_ROYALTIES]: result.royalties,
+        [AccountSortBy.MOST_SALES]: result.sales,
+      },
+    }))
+  }
+
+  async function count(filters: FetchOptions<AccountFilters, AccountSortBy>) {
+    const total = await accounts.count(filters)
+    return total
+  }
+
+  return {
+    fetch,
+    count,
+  }
+}

--- a/src/ports/accounts/component.ts
+++ b/src/ports/accounts/component.ts
@@ -1,0 +1,48 @@
+import { AccountFilters, ChainId, Network } from '@dcl/schemas'
+import { ISubgraphComponent } from '../subgraph/types'
+import { AccountFragment, IAccountsComponent } from './types'
+import { fromAccountFragment, getAccountsQuery } from './utils'
+
+export function createAccountsComponent(options: {
+  subgraph: ISubgraphComponent
+  network: Network
+  chainId: ChainId
+}): IAccountsComponent {
+  const { subgraph, network } = options
+
+  async function fetch(filters: AccountFilters) {
+    if (filters.network && filters.network !== network) {
+      return []
+    }
+
+    const query = getAccountsQuery(filters, {
+      withRoyalties: network === Network.MATIC,
+    })
+
+    const { accounts: fragments } = await subgraph.query<{
+      accounts: AccountFragment[]
+    }>(query)
+
+    const accounts = fragments.map((fragment) => fromAccountFragment(fragment))
+
+    return accounts
+  }
+
+  async function count(filters: AccountFilters) {
+    if (filters.network && filters.network !== network) {
+      return 0
+    }
+
+    const query = getAccountsQuery(filters, { isCount: true })
+    const { accounts: fragments } = await subgraph.query<{
+      accounts: AccountFragment[]
+    }>(query)
+
+    return fragments.length
+  }
+
+  return {
+    fetch,
+    count,
+  }
+}

--- a/src/ports/accounts/types.ts
+++ b/src/ports/accounts/types.ts
@@ -1,0 +1,16 @@
+import { Account, AccountFilters } from '@dcl/schemas'
+
+export interface IAccountsComponent {
+  fetch(filters: AccountFilters): Promise<Account[]>
+  count(filters: AccountFilters): Promise<number>
+}
+
+export type AccountFragment = {
+  id: string
+  address: string
+  sales: number
+  purchases: number
+  spent: string
+  earned: string
+  royalties: string
+}

--- a/src/ports/accounts/types.ts
+++ b/src/ports/accounts/types.ts
@@ -12,5 +12,5 @@ export type AccountFragment = {
   purchases: number
   spent: string
   earned: string
-  royalties: string
+  royalties?: string
 }

--- a/src/ports/accounts/utils.ts
+++ b/src/ports/accounts/utils.ts
@@ -11,7 +11,7 @@ export function fromAccountFragment(fragment: AccountFragment): Account {
     purchases: fragment.purchases,
     spent: fragment.spent,
     earned: fragment.earned,
-    royalties: fragment.royalties,
+    royalties: fragment.royalties || '0',
   }
 
   return account

--- a/src/ports/accounts/utils.ts
+++ b/src/ports/accounts/utils.ts
@@ -1,0 +1,98 @@
+import { Account, AccountFilters, AccountSortBy } from '@dcl/schemas'
+import { AccountFragment } from './types'
+
+export const ACCOUNT_DEFAULT_SORT_BY = AccountSortBy.MOST_EARNED
+
+export function fromAccountFragment(fragment: AccountFragment): Account {
+  const account: Account = {
+    id: fragment.id,
+    address: fragment.address,
+    sales: fragment.sales,
+    purchases: fragment.purchases,
+    spent: fragment.spent,
+    earned: fragment.earned,
+    royalties: fragment.royalties,
+  }
+
+  return account
+}
+
+export const getAccountFragment = (withRoyalties?: boolean) => `
+  fragment accountFragment on Account {
+    id
+    address
+    sales
+    purchases
+    spent
+    earned
+    ${withRoyalties ? 'royalties' : ''}
+  }
+`
+
+export function getAccountsQuery(
+  filters: AccountFilters,
+  options?: {
+    isCount?: boolean
+    withRoyalties?: boolean
+  }
+) {
+  const { first, skip, sortBy, id, address } = filters
+
+  const where: string[] = []
+
+  if (id) {
+    where.push(`id: "${id}"`)
+  }
+
+  if (address) {
+    where.push(`address: "${address}"`)
+  }
+
+  const max = 1000
+  const total = options?.isCount
+    ? max
+    : typeof first !== 'undefined'
+    ? typeof skip !== 'undefined'
+      ? skip + first
+      : first
+    : max
+
+  let orderBy: string
+  let orderDirection: string
+  switch (sortBy) {
+    case AccountSortBy.MOST_PURCHASES:
+      orderBy = 'purchases'
+      orderDirection = 'desc'
+      break
+    case AccountSortBy.MOST_ROYALTIES:
+      orderBy = 'royalties'
+      orderDirection = 'asc'
+      break
+    case AccountSortBy.MOST_SALES:
+      orderBy = 'sales'
+      orderDirection = 'desc'
+      break
+    case AccountSortBy.MOST_SPENT:
+      orderBy = 'spent'
+      orderDirection = 'desc'
+      break
+    default:
+      // AccountSortBy.MOST_EARNED
+      orderBy = 'earned'
+      orderDirection = 'desc'
+  }
+
+  return `
+    query Accounts {
+      accounts(
+        first: ${total}, 
+        orderBy: ${orderBy}, 
+        orderDirection: ${orderDirection}, 
+        where: {
+          ${where.join('\n')}
+        }) 
+        { ${options?.isCount ? 'id' : `...accountFragment`} }
+    }
+    ${options?.isCount ? '' : getAccountFragment(options?.withRoyalties)}
+  `
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,7 @@
 import {
+  Account,
+  AccountFilters,
+  AccountSortBy,
   Bid,
   BidFilters,
   BidSortBy,
@@ -61,6 +64,7 @@ export type AppComponents = {
   mints: IMergerComponent<Mint, MintFilters, MintSortBy>
   sales: IMergerComponent<Sale, SaleFilters, SaleSortBy>
   collections: IMergerComponent<Collection, CollectionFilters, CollectionSortBy>
+  accounts: IMergerComponent<Account, AccountFilters, AccountSortBy>
 }
 
 export type Context<Path extends string = any> = RoutedContext<


### PR DESCRIPTION
Add `/accounts` endpoint.

Returns a collection of the `Account` model which currently contains a bunch of metrics about earning and spending.