### PR TITLE
fix: sales type mint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,9 +104,9 @@ async function initComponents(): Promise<AppComponents> {
 
   // default config
   const defaultValues: Partial<AppConfig> = {
-    HTTP_SERVER_PORT: '5000',
-    HTTP_SERVER_HOST: '0.0.0.0',
-    API_VERSION: 'v1',
+    HTTP_SERVER_PORT: process.env.HTTP_SERVER_PORT || '5000',
+    HTTP_SERVER_HOST: process.env.HTTP_SERVER_HOST || '0.0.0.0',
+    API_VERSION: process.env.API_VERSION || 'v1',
   }
 
   const config = createConfigComponent(process.env, defaultValues)

--- a/src/ports/sales/component.ts
+++ b/src/ports/sales/component.ts
@@ -12,7 +12,9 @@ export function createSalesComponent(options: {
 
   function isValid(network: Network, filters: SaleFilters) {
     return (
+      // Querying a different network to the component's one is not valid
       (!filters.network || filters.network === network) &&
+      // Querying a SaleType.MINT on Ethereum is not valid
       (filters.type !== SaleType.MINT || network !== Network.ETHEREUM)
     )
   }

--- a/src/ports/sales/component.ts
+++ b/src/ports/sales/component.ts
@@ -1,4 +1,4 @@
-import { ChainId, Network, SaleFilters } from '@dcl/schemas'
+import { ChainId, Network, SaleFilters, SaleType } from '@dcl/schemas'
 import { ISubgraphComponent } from '../subgraph/types'
 import { SaleFragment, ISalesComponent } from './types'
 import { fromSaleFragment, getSalesQuery } from './utils'
@@ -11,7 +11,10 @@ export function createSalesComponent(options: {
   const { subgraph, network, chainId } = options
 
   async function fetch(filters: SaleFilters) {
-    if (filters.network && filters.network !== network) {
+    if (
+      (filters.network && filters.network !== network) ||
+      (filters.type === SaleType.MINT && network === Network.ETHEREUM)
+    ) {
       return []
     }
 
@@ -28,7 +31,10 @@ export function createSalesComponent(options: {
   }
 
   async function count(filters: SaleFilters) {
-    if (filters.network && filters.network !== network) {
+    if (
+      (filters.network && filters.network !== network) ||
+      (filters.type === SaleType.MINT && network === Network.ETHEREUM)
+    ) {
       return 0
     }
 

--- a/src/ports/sales/component.ts
+++ b/src/ports/sales/component.ts
@@ -10,11 +10,15 @@ export function createSalesComponent(options: {
 }): ISalesComponent {
   const { subgraph, network, chainId } = options
 
+  function isValid(network: Network, filters: SaleFilters) {
+    return (
+      (!filters.network || filters.network === network) &&
+      (filters.type !== SaleType.MINT || network !== Network.ETHEREUM)
+    )
+  }
+
   async function fetch(filters: SaleFilters) {
-    if (
-      (filters.network && filters.network !== network) ||
-      (filters.type === SaleType.MINT && network === Network.ETHEREUM)
-    ) {
+    if (!isValid(network, filters)) {
       return []
     }
 
@@ -31,10 +35,7 @@ export function createSalesComponent(options: {
   }
 
   async function count(filters: SaleFilters) {
-    if (
-      (filters.network && filters.network !== network) ||
-      (filters.type === SaleType.MINT && network === Network.ETHEREUM)
-    ) {
+    if (!isValid(network, filters)) {
       return 0
     }
 

--- a/src/ports/sales/utils.ts
+++ b/src/ports/sales/utils.ts
@@ -102,7 +102,7 @@ export function getSalesQuery(
   }
 
   if (type) {
-    where.push(`type: "${type}"`)
+    where.push(`type: ${type}`)
   }
 
   if (from) {


### PR DESCRIPTION
The Ethereum subgraphs don't have the `SaleType.MINT` so it throws when the query has that value.