### PR TITLE
fix: Improve NFT fetch performance on rentals

### DIFF
--- a/src/adapters/sources/rentals.ts
+++ b/src/adapters/sources/rentals.ts
@@ -24,9 +24,14 @@ export function createRentalsNFTSource(
   ): Promise<Sortable<NFTResult, NFTSortBy>[]> {
     const tokenIdsOfRentals = rentals.map((rental) => rental.nftId)
     const nftResultsOfRentals = await nfts.fetchByTokenIds(tokenIdsOfRentals)
-    const nftResultsOfRentalsById = Object.fromEntries(
-      nftResultsOfRentals.map((nft) => [nft.nft.id, nft])
+    const nftResultsOfRentalsById = nftResultsOfRentals.reduce(
+      (accumulator, nftResult) => {
+        accumulator[nftResult.nft.id] = nftResult
+        return accumulator
+      },
+      {} as Record<string, NFTResult>
     )
+
     return rentals
       .map((rental) => {
         let nftResultForRental =

--- a/src/adapters/sources/rentals.ts
+++ b/src/adapters/sources/rentals.ts
@@ -12,6 +12,7 @@ import {
   Sortable,
 } from '../../ports/merger/types'
 import { INFTsComponent, NFTResult } from '../../ports/nfts/types'
+import { getId } from '../../ports/nfts/utils'
 import { IRentalsComponent } from '../../ports/rentals/types'
 
 export function createRentalsNFTSource(
@@ -21,22 +22,23 @@ export function createRentalsNFTSource(
   async function enhanceRentalListing(
     rentals: RentalListing[]
   ): Promise<Sortable<NFTResult, NFTSortBy>[]> {
-    const tokenIdsOfRentals = rentals.map((rental) => rental.tokenId)
+    const tokenIdsOfRentals = rentals.map((rental) => rental.nftId)
     const nftResultsOfRentals = await nfts.fetchByTokenIds(tokenIdsOfRentals)
     const nftResultsOfRentalsById = Object.fromEntries(
       nftResultsOfRentals.map((nft) => [nft.nft.id, nft])
     )
-
     return rentals
       .map((rental) => {
-        if (!nftResultsOfRentalsById[rental.nftId]) {
+        let nftResultForRental =
+          nftResultsOfRentalsById[getId(rental.contractAddress, rental.tokenId)]
+        if (!nftResultForRental) {
           throw new Error('NFT for the rental listing was not found')
         }
 
         return {
-          ...nftResultsOfRentalsById[rental.nftId],
+          ...nftResultForRental,
           nft: {
-            ...nftResultsOfRentalsById[rental.nftId].nft,
+            ...nftResultForRental.nft,
             openRentalId: rental.id,
           },
           rental,

--- a/src/logic/nfts/rentals.ts
+++ b/src/logic/nfts/rentals.ts
@@ -31,8 +31,7 @@ export function shouldFetch(filters: NFTFilters): boolean {
     filters.category &&
     filters.category !== NFTCategory.ESTATE &&
     filters.category !== NFTCategory.PARCEL
-  const landFilterIsSetAndIsNotLAND =
-    filters.isLand !== undefined && !filters.isLand
+  const categoriesIsNotSetAndIsNotLand = !filters.category && !filters.isLand
   const prohibitedFilterIsSet = PROHIBITED_FILTERS.some(
     (prohibitedFilter) =>
       setFilters.includes(prohibitedFilter) &&
@@ -46,7 +45,7 @@ export function shouldFetch(filters: NFTFilters): boolean {
       prohibitedSortingIsSet ||
       prohibitedFilterIsSet ||
       categoriesIsSetAndIsNotLAND ||
-      landFilterIsSetAndIsNotLAND
+      categoriesIsNotSetAndIsNotLand
     ) && Boolean(filters.isOnRent)
   )
 }

--- a/src/ports/nfts/component.ts
+++ b/src/ports/nfts/component.ts
@@ -1,7 +1,12 @@
 import { NFTFilters, NFTSortBy } from '@dcl/schemas'
 import { ISubgraphComponent } from '@well-known-components/thegraph-component'
 import { INFTsComponent, NFTResult } from './types'
-import { getFetchOneQuery, getFetchQuery, getQueryVariables } from './utils'
+import {
+  getByTokenIdQuery,
+  getFetchOneQuery,
+  getFetchQuery,
+  getQueryVariables,
+} from './utils'
 
 export function createNFTComponent<T extends { id: string }>(options: {
   subgraph: ISubgraphComponent
@@ -81,9 +86,25 @@ export function createNFTComponent<T extends { id: string }>(options: {
     }
   }
 
+  /**
+   * Fetches up to 1000 NFTs by their token IDs.
+   */
+  async function fetchByTokenIds(tokenIds: string[]): Promise<NFTResult[]> {
+    const query = getByTokenIdQuery(fragmentName, getFragment)
+    const variables = {
+      tokenIds,
+    }
+    const { nfts } = await subgraph.query<{
+      nfts: T[]
+    }>(query, variables)
+
+    return nfts.map(fromFragment)
+  }
+
   return {
     fetch,
     fetchOne,
+    fetchByTokenIds,
     count,
   }
 }

--- a/src/ports/nfts/types.ts
+++ b/src/ports/nfts/types.ts
@@ -15,5 +15,6 @@ export type QueryVariables = Omit<NFTFilters, 'sortBy'> & {
 export interface INFTsComponent {
   fetch(filters: NFTFilters): Promise<NFTResult[]>
   fetchOne(contractAddress: string, tokenId: string): Promise<NFTResult | null>
+  fetchByTokenIds(tokenIds: string[]): Promise<NFTResult[]>
   count(filters: NFTFilters): Promise<number>
 }

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -196,6 +196,23 @@ export function getFetchOneQuery(
     `
 }
 
+export function getByTokenIdQuery(
+  fragmentName: string,
+  getFragment: () => string
+) {
+  return `
+  query NFTByTokenId($tokenIds: String) {
+    nfts(
+      where: { id_in: $tokenIds: [String!] }
+      first: 1000
+      ) {
+        ...${fragmentName}
+      }
+    }
+    ${getFragment()}
+    `
+}
+
 export function getId(contractAddress: string, tokenId: string) {
   return `${contractAddress}-${tokenId}`
 }

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -201,9 +201,9 @@ export function getByTokenIdQuery(
   getFragment: () => string
 ) {
   return `
-  query NFTByTokenId($tokenIds: String) {
+  query NFTByTokenId($tokenIds: [String!]) {
     nfts(
-      where: { id_in: $tokenIds: [String!] }
+      where: { id_in: $tokenIds }
       first: 1000
       ) {
         ...${fragmentName}

--- a/src/tests/adapters/sources/nft-source.spec.ts
+++ b/src/tests/adapters/sources/nft-source.spec.ts
@@ -23,6 +23,7 @@ let options: {
 }
 let fetchMock: jest.Mock
 let fetchOneMock: jest.Mock
+let fetchByTokenIdsMock: jest.Mock
 let countMock: jest.Mock
 let shouldFetchMock: jest.Mock
 let getRentalsListingsMock: jest.Mock
@@ -30,6 +31,7 @@ let getOpenRentalsListingsOfNFTsMock: jest.Mock
 
 beforeEach(() => {
   fetchMock = jest.fn()
+  fetchByTokenIdsMock = jest.fn()
   countMock = jest.fn()
   fetchOneMock = jest.fn()
   shouldFetchMock = jest.fn()
@@ -39,6 +41,7 @@ beforeEach(() => {
   nftComponentMock = {
     fetch: fetchMock,
     fetchOne: fetchOneMock,
+    fetchByTokenIds: fetchByTokenIdsMock,
     count: countMock,
   }
 

--- a/src/tests/adapters/sources/rentals-source.spec.ts
+++ b/src/tests/adapters/sources/rentals-source.spec.ts
@@ -5,6 +5,7 @@ import { SignaturesServerPaginatedResponse } from '../../../ports/rentals/types'
 import { INFTsComponent, NFTResult } from '../../../ports/nfts/types'
 import { IRentalsComponent } from '../../../ports/rentals/types'
 import { convertNFTResultToSortableResult } from '../../../logic/nfts/utils'
+import { getId } from '../../../ports/nfts/utils'
 
 let rentalsNFTSource: IMergerComponent.Source<NFTResult, NFTFilters, NFTSortBy>
 let rentalsComponentMock: IRentalsComponent
@@ -57,7 +58,7 @@ describe('when fetching rented nfts', () => {
         data: {
           results: Array.from({ length: 5 }, (_, i) => ({
             id: i.toString(),
-            nftId: `nft-id-${i}`,
+            nftId: `parcel-${i}`,
             contractAddress: `contractAddress-${i}`,
             tokenId: `tokenId-${i}`,
             startedAt: Date.now(),
@@ -71,8 +72,10 @@ describe('when fetching rented nfts', () => {
       }
       nftResults = rentalsResponse.data.results.map((rental) => ({
         nft: {
-          id: rental.nftId,
+          id: getId(rental.contractAddress, rental.tokenId),
           name: `nft-${rental.id}`,
+          contractAddress: `contractAddress-${rental.id}`,
+          tokenId: `tokenId-${rental.id}`,
           openRentalId: rental.id,
           createdAt: Date.now(),
           soldAt: Date.now(),
@@ -86,7 +89,7 @@ describe('when fetching rented nfts', () => {
 
     it('should return the fetched nfts', async () => {
       return expect(
-        rentalsNFTSource.fetch!({ isOnRent: true })
+        rentalsNFTSource.fetch!({ isOnRent: true, isLand: true })
       ).resolves.toEqual(
         nftResults
           .map((nftResult, i) => ({
@@ -107,7 +110,7 @@ describe('when fetching rented nfts', () => {
 
     it('should reject propagating the error', () => {
       return expect(
-        rentalsNFTSource.fetch!({ isOnRent: true })
+        rentalsNFTSource.fetch!({ isOnRent: true, isLand: true })
       ).rejects.toThrowError('An error occurred')
     })
   })
@@ -147,7 +150,7 @@ describe('when counting rented nfts', () => {
 
     it('should return the number of fetched nfts', () => {
       return expect(
-        rentalsNFTSource.count({ isOnRent: true })
+        rentalsNFTSource.count({ isOnRent: true, isLand: true })
       ).resolves.toEqual(rentalsResponse.data.total)
     })
   })
@@ -161,7 +164,7 @@ describe('when counting rented nfts', () => {
 
     it('should reject propagating the error', () => {
       return expect(
-        rentalsNFTSource.count!({ isOnRent: true })
+        rentalsNFTSource.count!({ isOnRent: true, isLand: true })
       ).rejects.toThrowError('An error occurred')
     })
   })
@@ -186,7 +189,7 @@ describe('when fetching and counting rented nfts', () => {
         data: {
           results: Array.from({ length: 5 }, (_, i) => ({
             id: i.toString(),
-            nftId: `nft-id-${i}`,
+            nftId: `parcel-${i}`,
             contractAddress: `contractAddress-${i}`,
             tokenId: `tokenId-${i}`,
             startedAt: Date.now(),
@@ -200,7 +203,7 @@ describe('when fetching and counting rented nfts', () => {
       }
       nftResults = rentalsResponse.data.results.map((rental) => ({
         nft: {
-          id: rental.nftId,
+          id: getId(rental.contractAddress, rental.tokenId),
           name: `nft-${rental.id}`,
           openRentalId: rental.id,
           createdAt: Date.now(),
@@ -216,7 +219,7 @@ describe('when fetching and counting rented nfts', () => {
 
     it('should return the count and the fetched nfts', () => {
       return expect(
-        rentalsNFTSource.fetchAndCount!({ isOnRent: true })
+        rentalsNFTSource.fetchAndCount!({ isOnRent: true, isLand: true })
       ).resolves.toEqual({
         data: nftResults
           .map((nftResult, i) => ({
@@ -238,7 +241,7 @@ describe('when fetching and counting rented nfts', () => {
 
     it('should reject propagating the error', () => {
       return expect(
-        rentalsNFTSource.fetchAndCount!({ isOnRent: true })
+        rentalsNFTSource.fetchAndCount!({ isOnRent: true, isLand: true })
       ).rejects.toThrowError('An error occurred')
     })
   })

--- a/src/tests/adapters/sources/rentals-source.spec.ts
+++ b/src/tests/adapters/sources/rentals-source.spec.ts
@@ -13,12 +13,14 @@ let getRentalsListingsMock: jest.Mock
 let getOpenRentalsListingsOfNFTsMock: jest.Mock
 let fetchMock: jest.Mock
 let fetchOneMock: jest.Mock
+let fetchByTokenIdsMock: jest.Mock
 let countMock: jest.Mock
 let rentalsResponse: SignaturesServerPaginatedResponse<RentalListing[]>
 let nftResults: NFTResult[]
 
 beforeEach(() => {
   getRentalsListingsMock = jest.fn()
+  fetchByTokenIdsMock = jest.fn()
   getOpenRentalsListingsOfNFTsMock = jest.fn()
   fetchMock = jest.fn()
   fetchOneMock = jest.fn()
@@ -30,6 +32,7 @@ beforeEach(() => {
   nftsComponentsMock = {
     fetch: fetchMock,
     fetchOne: fetchOneMock,
+    fetchByTokenIds: fetchByTokenIdsMock,
     count: countMock,
   }
   rentalsNFTSource = createRentalsNFTSource(
@@ -54,6 +57,7 @@ describe('when fetching rented nfts', () => {
         data: {
           results: Array.from({ length: 5 }, (_, i) => ({
             id: i.toString(),
+            nftId: `nft-id-${i}`,
             contractAddress: `contractAddress-${i}`,
             tokenId: `tokenId-${i}`,
             startedAt: Date.now(),
@@ -67,6 +71,7 @@ describe('when fetching rented nfts', () => {
       }
       nftResults = rentalsResponse.data.results.map((rental) => ({
         nft: {
+          id: rental.nftId,
           name: `nft-${rental.id}`,
           openRentalId: rental.id,
           createdAt: Date.now(),
@@ -75,14 +80,11 @@ describe('when fetching rented nfts', () => {
         order: null,
         rental: null,
       }))
-      rentalsResponse.data.results.forEach((_, i) => {
-        fetchOneMock.mockResolvedValueOnce(nftResults[i])
-      })
-
+      fetchByTokenIdsMock.mockResolvedValueOnce(nftResults)
       getRentalsListingsMock.mockResolvedValueOnce(rentalsResponse)
     })
 
-    it('should return the fetched nfts', () => {
+    it('should return the fetched nfts', async () => {
       return expect(
         rentalsNFTSource.fetch!({ isOnRent: true })
       ).resolves.toEqual(
@@ -127,6 +129,7 @@ describe('when counting rented nfts', () => {
         data: {
           results: Array.from({ length: 5 }, (_, i) => ({
             id: i.toString(),
+            nftId: `nft-id-${i}`,
             contractAddress: `contractAddress-${i}`,
             tokenId: `tokenId-${i}`,
             startedAt: Date.now(),
@@ -183,6 +186,7 @@ describe('when fetching and counting rented nfts', () => {
         data: {
           results: Array.from({ length: 5 }, (_, i) => ({
             id: i.toString(),
+            nftId: `nft-id-${i}`,
             contractAddress: `contractAddress-${i}`,
             tokenId: `tokenId-${i}`,
             startedAt: Date.now(),
@@ -196,6 +200,7 @@ describe('when fetching and counting rented nfts', () => {
       }
       nftResults = rentalsResponse.data.results.map((rental) => ({
         nft: {
+          id: rental.nftId,
           name: `nft-${rental.id}`,
           openRentalId: rental.id,
           createdAt: Date.now(),
@@ -204,10 +209,8 @@ describe('when fetching and counting rented nfts', () => {
         order: null,
         rental: null,
       }))
-      rentalsResponse.data.results.forEach((_, i) => {
-        fetchOneMock.mockResolvedValueOnce(nftResults[i])
-      })
 
+      fetchByTokenIdsMock.mockResolvedValueOnce(nftResults)
       getRentalsListingsMock.mockResolvedValueOnce(rentalsResponse)
     })
 

--- a/src/tests/logic/nft-rentals.spec.ts
+++ b/src/tests/logic/nft-rentals.spec.ts
@@ -5,11 +5,13 @@ import {
   shouldFetch,
 } from '../../logic/nfts/rentals'
 
-describe('when checking if the rental should be checked', () => {
+describe('when checking if the rental should be fetched', () => {
   PROHIBITED_FILTERS.forEach((filter) => {
     describe(`and the filter ${filter} is set which is prohibited`, () => {
       it('should return false', () => {
-        expect(shouldFetch({ [filter]: true, isOnRent: true })).toBe(false)
+        expect(
+          shouldFetch({ [filter]: true, isOnRent: true, isLand: true })
+        ).toBe(false)
       })
     })
   })
@@ -17,7 +19,9 @@ describe('when checking if the rental should be checked', () => {
   PROHIBITED_SORTING.forEach((sortBy) => {
     describe(`and the sort by filter is set to ${sortBy} which is prohibited`, () => {
       it('should return false', () => {
-        expect(shouldFetch({ sortBy, isOnRent: true })).toBe(false)
+        expect(shouldFetch({ sortBy, isOnRent: true, isLand: true })).toBe(
+          false
+        )
       })
     })
   })
@@ -43,15 +47,21 @@ describe('when checking if the rental should be checked', () => {
     })
   })
 
-  describe('and the isOnRent filter is not true', () => {
+  describe('and the isOnRent filter is not true but the isLand one is', () => {
     it('should return false', () => {
-      expect(shouldFetch({ isOnRent: false })).toBe(false)
+      expect(shouldFetch({ isOnRent: false, isLand: true })).toBe(false)
     })
   })
 
-  describe('and the isOnRent filter is set to true', () => {
+  describe('and the isOnRent and isLand filter are set to true', () => {
     it('should return true', () => {
-      expect(shouldFetch({ isOnRent: true })).toBe(true)
+      expect(shouldFetch({ isOnRent: true, isLand: true })).toBe(true)
+    })
+  })
+
+  describe('and the isOnRent filter is set but isLand is set to false', () => {
+    it('should return false', () => {
+      expect(shouldFetch({ isOnRent: true, isLand: false })).toBe(false)
     })
   })
   ;[(NFTCategory.ESTATE, NFTCategory.PARCEL)].forEach((category) => {
@@ -73,7 +83,9 @@ describe('when checking if the rental should be checked', () => {
   ].forEach((filter) => {
     describe(`and the filter ${filter} filter is set which is permitted`, () => {
       it('should return true', () => {
-        expect(shouldFetch({ isOnRent: true, [filter]: true })).toBe(true)
+        expect(
+          shouldFetch({ isOnRent: true, isLand: true, [filter]: true })
+        ).toBe(true)
       })
     })
   })

--- a/src/tests/ports/nfts.spec.ts
+++ b/src/tests/ports/nfts.spec.ts
@@ -1,0 +1,87 @@
+import { NFTCategory } from '@dcl/schemas'
+import { ISubgraphComponent } from '@well-known-components/thegraph-component'
+import {
+  getMarketplaceFragment,
+  fromMarketplaceNFTFragment,
+  getMarketplaceOrderBy,
+  getMarketplaceExtraVariables,
+  getMarketplaceExtraWhere,
+  MarketplaceNFTFragment,
+} from '../../../src/logic/nfts/marketplace'
+import { createNFTComponent } from '../../../src/ports/nfts/component'
+import { INFTsComponent } from '../../ports/nfts/types'
+
+let marketplaceSubgraphMock: ISubgraphComponent
+let queryMock: jest.Mock
+let nftComponentMock: INFTsComponent
+
+beforeEach(() => {
+  queryMock = jest.fn()
+  marketplaceSubgraphMock = {
+    query: queryMock,
+  }
+
+  nftComponentMock = createNFTComponent({
+    subgraph: marketplaceSubgraphMock,
+    fragmentName: 'marketplaceFragment',
+    getFragment: getMarketplaceFragment,
+    fromFragment: fromMarketplaceNFTFragment,
+    getSortByProp: getMarketplaceOrderBy,
+    getExtraVariables: getMarketplaceExtraVariables,
+    getExtraWhere: getMarketplaceExtraWhere,
+  })
+})
+
+describe('when fetching tokens by ids', () => {
+  let tokenIds: string[] = ['1', '2', '3']
+
+  describe('and the request fails', () => {
+    beforeEach(() => {
+      queryMock.mockRejectedValueOnce(new Error('An error occurred'))
+    })
+
+    it('should propagate the error', () => {
+      return expect(
+        nftComponentMock.fetchByTokenIds(tokenIds)
+      ).rejects.toThrowError('An error occurred')
+    })
+  })
+
+  describe('and the request is successful', () => {
+    let nftFragments: MarketplaceNFTFragment[]
+
+    beforeEach(() => {
+      nftFragments = Array.from({ length: 4 }, (_, i) => ({
+        id: `contractAddress-${i.toString()}-tokenId-${i.toString()}`,
+        name: `name-${i}`,
+        image: null,
+        contractAddress: `contractAddress-${i}`,
+        tokenId: `tokenId-${i}`,
+        category: NFTCategory.PARCEL,
+        owner: {
+          address: '0x0',
+        },
+        parcel: {
+          x: '1',
+          y: i.toString(),
+          data: null,
+          estate: null,
+        },
+        createdAt: Date.now().toString(),
+        updatedAt: Date.now().toString(),
+        soldAt: Date.now().toString(),
+        searchOrderPrice: '10000',
+        searchOrderCreatedAt: 'Date.now().toString()',
+        activeOrder: null,
+      }))
+
+      queryMock.mockResolvedValueOnce({ nfts: nftFragments })
+    })
+
+    it('should return the converted fragment of nfts', () => {
+      return expect(
+        nftComponentMock.fetchByTokenIds(tokenIds)
+      ).resolves.toEqual(nftFragments.map(fromMarketplaceNFTFragment))
+    })
+  })
+})


### PR DESCRIPTION
This PR improves the NFT fetching procedure when rentals are requests by using `id_in`.
This PR also fixes the should fetch function of the rentals source to check the `isLand` parameter when there's no category set.