### PR TITLE
feat: add recursive fetch to rankings query

### DIFF
--- a/src/ports/rankings/utils.ts
+++ b/src/ports/rankings/utils.ts
@@ -106,7 +106,7 @@ function getQueryParams(entity: RankingEntity, filters: RankingsFilters) {
 export function getRankingQuery(
   entity: RankingEntity,
   filters: RankingsFilters,
-  page: number
+  page = 0
 ) {
   switch (entity) {
     case RankingEntity.WEARABLES:
@@ -146,7 +146,7 @@ export function consolidateRankingResults(
 export function getItemsDayDataQuery(
   entity: RankingEntity,
   filters: RankingsFilters,
-  page: number
+  page = 0
 ) {
   const { where, orderBy, orderDirection } = getQueryParams(entity, filters)
 
@@ -219,10 +219,7 @@ export const getCreatorsTotalFragment = () => `
   }
 `
 
-export function getCreatorsDayDataQuery(
-  filters: RankingsFilters,
-  page: number
-) {
+export function getCreatorsDayDataQuery(filters: RankingsFilters, page = 0) {
   const { where, orderBy, orderDirection } = getQueryParams(
     RankingEntity.CREATORS,
     filters
@@ -273,10 +270,7 @@ export const getCollectorsTotalFragment = () => `
   }
 `
 
-export function getCollectorsDayDataQuery(
-  filters: RankingsFilters,
-  page: number
-) {
+export function getCollectorsDayDataQuery(filters: RankingsFilters, page = 0) {
   const { where, orderBy, orderDirection } = getQueryParams(
     RankingEntity.COLLECTORS,
     filters

--- a/src/ports/rankings/utils.ts
+++ b/src/ports/rankings/utils.ts
@@ -19,6 +19,8 @@ import {
   CreatorsDayDataFragment,
 } from './types'
 
+export const MAX_RESULTS = 1000
+
 export const getItemsDayDataFragment = () => `
   fragment itemsDayDataFragment on ItemsDayData {
     id
@@ -103,17 +105,18 @@ function getQueryParams(entity: RankingEntity, filters: RankingsFilters) {
 
 export function getRankingQuery(
   entity: RankingEntity,
-  filters: RankingsFilters
+  filters: RankingsFilters,
+  page: number
 ) {
   switch (entity) {
     case RankingEntity.WEARABLES:
-      return getItemsDayDataQuery(RankingEntity.WEARABLES, filters)
+      return getItemsDayDataQuery(RankingEntity.WEARABLES, filters, page)
     case RankingEntity.EMOTES:
-      return getItemsDayDataQuery(RankingEntity.EMOTES, filters)
+      return getItemsDayDataQuery(RankingEntity.EMOTES, filters, page)
     case RankingEntity.CREATORS:
-      return getCreatorsDayDataQuery(filters)
+      return getCreatorsDayDataQuery(filters, page)
     case RankingEntity.COLLECTORS:
-      return getCollectorsDayDataQuery(filters)
+      return getCollectorsDayDataQuery(filters, page)
   }
 }
 
@@ -142,7 +145,8 @@ export function consolidateRankingResults(
 
 export function getItemsDayDataQuery(
   entity: RankingEntity,
-  filters: RankingsFilters
+  filters: RankingsFilters,
+  page: number
 ) {
   const { where, orderBy, orderDirection } = getQueryParams(entity, filters)
 
@@ -160,6 +164,8 @@ export function getItemsDayDataQuery(
     `
     : `query ItemsDayData {
         rankings: itemsDayDatas(orderBy: ${orderBy}, 
+          first: ${MAX_RESULTS},
+          skip: ${MAX_RESULTS * page}
           orderDirection: ${orderDirection}, 
           where: { ${where.join('\n')} }) {
           ...itemsDayDataFragment
@@ -213,7 +219,10 @@ export const getCreatorsTotalFragment = () => `
   }
 `
 
-export function getCreatorsDayDataQuery(filters: RankingsFilters) {
+export function getCreatorsDayDataQuery(
+  filters: RankingsFilters,
+  page: number
+) {
   const { where, orderBy, orderDirection } = getQueryParams(
     RankingEntity.CREATORS,
     filters
@@ -232,6 +241,8 @@ export function getCreatorsDayDataQuery(filters: RankingsFilters) {
       ${getCreatorsTotalFragment()}`
     : `query AccountsDayData {
         rankings: accountsDayDatas(orderBy: ${orderBy}, 
+          first: ${MAX_RESULTS},
+          skip: ${MAX_RESULTS * page}
           orderDirection: ${orderDirection}, 
           where: { ${where.join('\n')} }) {
           ...creatorsDayDataFragment
@@ -262,7 +273,10 @@ export const getCollectorsTotalFragment = () => `
   }
 `
 
-export function getCollectorsDayDataQuery(filters: RankingsFilters) {
+export function getCollectorsDayDataQuery(
+  filters: RankingsFilters,
+  page: number
+) {
   const { where, orderBy, orderDirection } = getQueryParams(
     RankingEntity.COLLECTORS,
     filters
@@ -281,6 +295,8 @@ export function getCollectorsDayDataQuery(filters: RankingsFilters) {
       ${getCollectorsTotalFragment()}`
     : `query AccountsDayData {
         rankings: accountsDayDatas(orderBy: ${orderBy}, 
+          first: ${MAX_RESULTS},
+          skip: ${MAX_RESULTS * page}
           orderDirection: ${orderDirection}, 
           where: { ${where.join('\n')} }) {
           ...collectorsDayDataFragment


### PR DESCRIPTION
Closes #131

Both by volume and by sales are returning the same values now:

![image](https://user-images.githubusercontent.com/8763687/191261599-8df31a96-c84a-4a3b-8e48-9ff991cb5280.png)
![image](https://user-images.githubusercontent.com/8763687/191261643-fe2f37f4-634d-4f87-929b-3ae61de330d2.png)
