### PR TITLE
feat: converted single contract address filter into multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ type Item = {
 - `emoteCategory`: Filter results by `EmoteCategory`. Possible values: `dance`, `stunt`, `greetings`, `fun`, `poses`, `reactions`, `horror`, `miscellaneous`.
 - `emoteGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
 - `emotePlayMode`: Filter results by `EmotePlayMode`. Possible values: `simple`, `loop`
-- `contractAddress`: Filter results by contract address. Type: `address`.
+- `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `itemId`: Filter results by `itemId`. Type: `string`.
 - `network`: Filter results by `Network`. Possible values: `ETHEREUM`, `MATIC`.
 
@@ -459,5 +459,3 @@ type RankingItem = {
 - `first`: Limit the number of results. Type: number.
 - `rarity`: Filter the results by the rarity. Possible values: `unique`, `mythic`, `legendary`, `epic`, `rare`, `uncommon`, `common`.
 - `category`: Filter the results by wearable category. Possible values: `eyebrows`,`eyes`,`facial_hair`,`hair`,`mouth`,`upper_body`,`lower_body`,`feet`,`earring`,`eyewear`,`hat`,`helmet`,`mask`,`tiara`,`top_head`, `skin`.
-
-.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^5.20.0",
+        "@dcl/schemas": "^5.21.0",
         "@types/sqlite3": "^3.1.7",
         "@well-known-components/env-config-provider": "^1.1.1",
         "@well-known-components/http-server": "^1.0.0",
@@ -597,9 +597,9 @@
       "dev": true
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.20.0.tgz",
-      "integrity": "sha512-CzHzGdtwaPNEeoYhbuBGxp7BFSZQyGLsrWRi8relrbFpPEM0VGvkDzbb6C6aHo2lM+PiSxqQ0fw3PvpTiFvLgQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.21.0.tgz",
+      "integrity": "sha512-QlUCXf0AV/D3itxgZqQW+0z3PKQBXlmwHVDUsejfnNo6ycQwIdCWQMzI4QKxBKnyVHoieBOSMgvLaMJXb7JXpA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -10587,9 +10587,9 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.20.0.tgz",
-      "integrity": "sha512-CzHzGdtwaPNEeoYhbuBGxp7BFSZQyGLsrWRi8relrbFpPEM0VGvkDzbb6C6aHo2lM+PiSxqQ0fw3PvpTiFvLgQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.21.0.tgz",
+      "integrity": "sha512-QlUCXf0AV/D3itxgZqQW+0z3PKQBXlmwHVDUsejfnNo6ycQwIdCWQMzI4QKxBKnyVHoieBOSMgvLaMJXb7JXpA==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "printWidth": 80
   },
   "dependencies": {
-    "@dcl/schemas": "^5.20.0",
+    "@dcl/schemas": "^5.21.0",
     "@types/sqlite3": "^3.1.7",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/http-server": "^1.0.0",

--- a/src/adapters/handlers/items.ts
+++ b/src/adapters/handlers/items.ts
@@ -48,8 +48,11 @@ export function createItemsHandler(
       'emoteGender',
       WearableGender
     )
-    const emotePlayMode = params.getValue<EmotePlayMode>('emotePlayMode', EmotePlayMode)
-    const contractAddress = params.getAddress('contractAddress')
+    const emotePlayMode = params.getValue<EmotePlayMode>(
+      'emotePlayMode',
+      EmotePlayMode
+    )
+    const contractAddresses = params.getList('contractAddress')
     const itemId = params.getString('itemId')
     const network = params.getValue<Network>('network', Network)
 
@@ -71,7 +74,7 @@ export function createItemsHandler(
         emoteCategory,
         emoteGenders,
         emotePlayMode,
-        contractAddress,
+        contractAddresses,
         itemId,
         isWearableSmart,
         network,

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -146,7 +146,7 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     wearableGenders,
     emoteCategory,
     emoteGenders,
-    contractAddress,
+    contractAddresses,
     itemId,
   } = filters as ItemFilters
 
@@ -192,8 +192,12 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     where.push(`searchText_contains: "${search.trim().toLowerCase()}"`)
   }
 
-  if (contractAddress) {
-    where.push(`collection: "${contractAddress}"`)
+  if (contractAddresses) {
+    where.push(
+      `collection_in: [${contractAddresses
+        .map((contractAddress) => `"${contractAddress}"`)
+        .join(',')}]`
+    )
   }
 
   if (itemId) {

--- a/src/ports/trendings/component.ts
+++ b/src/ports/trendings/component.ts
@@ -73,7 +73,7 @@ export function createTrendingsComponent(
           Object.keys(trendingSales).map((key) => {
             const [contractAddress, itemId] = key.split('-')
             return itemsComponent.fetch({
-              contractAddress,
+              contractAddresses: [contractAddress],
               itemId: itemId || undefined,
             })
           })
@@ -103,7 +103,13 @@ export function createTrendingsComponent(
       [...Object.entries(trendingSales)].sort((a, b) => {
         const itemA = findItemByItemId(items, a[0])
         const itemB = findItemByItemId(items, b[0])
-        return !!itemA && !!itemB && new BN(itemB.price)
+        if (!itemA) {
+          return 1
+        }
+        if (!itemB) {
+          return -1
+        }
+        return new BN(itemB.price)
           .mul(new BN(b[1]))
           .gt(new BN(itemA.price).mul(new BN(a[1])))
           ? 1

--- a/src/tests/ports/trendings.spec.ts
+++ b/src/tests/ports/trendings.spec.ts
@@ -111,8 +111,8 @@ test('trendings component', function ({ components }) {
 
         jest
           .spyOn(items, 'fetch')
-          .mockImplementation(({ contractAddress, itemId }) =>
-            Promise.resolve([getItem(contractAddress!, itemId!)])
+          .mockImplementation(({ contractAddresses, itemId }) =>
+            Promise.resolve([getItem(contractAddresses![0], itemId!)])
           )
       })
 


### PR DESCRIPTION
This PR adds support for multiple `contractAddress` params in the `/items` endpoint

Closes #136