### PR TITLE
fix: LAND not returning correctly when rented

### DIFF
--- a/src/ports/rentalNFTs/component.ts
+++ b/src/ports/rentalNFTs/component.ts
@@ -76,8 +76,11 @@ export function createRentalsNFTComponent(options: {
    */
   async function fetch(filters: NFTFilters): Promise<NFTResult[]> {
     const rentalAssets = await getRentalAssets(filters)
-    const mktFilters = makeFiltersForMarketplaceComponent(filters, rentalAssets)
-    return marketplaceNFTsComponent.fetch(mktFilters)
+    return rentalAssets.length > 0
+      ? marketplaceNFTsComponent.fetch(
+          makeFiltersForMarketplaceComponent(filters, rentalAssets)
+        )
+      : []
   }
 
   /**
@@ -85,8 +88,11 @@ export function createRentalsNFTComponent(options: {
    */
   async function count(filters: NFTFilters): Promise<number> {
     const rentalAssets = await getRentalAssets(filters)
-    const mktFilters = makeFiltersForMarketplaceComponent(filters, rentalAssets)
-    return marketplaceNFTsComponent.count(mktFilters)
+    return rentalAssets.length > 0
+      ? marketplaceNFTsComponent.count(
+          makeFiltersForMarketplaceComponent(filters, rentalAssets)
+        )
+      : 0
   }
 
   /**

--- a/src/ports/rentals/components.ts
+++ b/src/ports/rentals/components.ts
@@ -222,7 +222,7 @@ export function createRentalsComponent(
 
       const where: string[] = []
 
-      if (filters.contractAddresses && filters.contractAddresses.length > 1) {
+      if (filters.contractAddresses && filters.contractAddresses.length > 0) {
         where.push(
           `contractAddress_in:[${filters.contractAddresses
             .map((contractAddress) => `"${contractAddress}"`)
@@ -230,7 +230,7 @@ export function createRentalsComponent(
         )
       }
 
-      if (filters.tokenIds && filters.tokenIds.length > 1) {
+      if (filters.tokenIds && filters.tokenIds.length > 0) {
         where.push(
           `tokenId_in:[${filters.tokenIds
             .map((tokenId) => `"${tokenId}"`)
@@ -238,7 +238,7 @@ export function createRentalsComponent(
         )
       }
 
-      if (filters.lessors && filters.lessors.length > 1) {
+      if (filters.lessors && filters.lessors.length > 0) {
         where.push(
           `lessor_in:[${filters.lessors
             .map((lessor) => `"${lessor}"`)


### PR DESCRIPTION
This PR fixes the requests that use the `owner` property by querying by lessor when asking for the owners (it was checking for an array with at least two elements) and by not querying for marketplace NFTs when there are no NFTs rented.