### PR TITLE
feat: fetch nfts if the category is estate/parcel as well

### DIFF
--- a/src/logic/nfts/rentals.ts
+++ b/src/logic/nfts/rentals.ts
@@ -86,7 +86,10 @@ export function rentalNFTComponentShouldFetch(filters: NFTFilters): boolean {
     // The lookup for assets on rent is done by another component.
     !filters.isOnRent &&
     // Only Lands and Estates can be locked in the rentals contract.
-    !!filters.isLand &&
+    (!!filters.isLand ||
+      (!!filters.category &&
+        (filters.category === NFTCategory.ESTATE ||
+          filters.category === NFTCategory.PARCEL))) &&
     // The rentals subgraph is queried mainly by lessor, se this param is required.
     !!filters.owner
   )


### PR DESCRIPTION
Closes #1062

after the change:

`/v1/nfts?first=24&skip=0&sortBy=newest&category=estate&owner=0x747c6f502272129bf1ba872a1903045b837ee86c&rentalStatus=open&rentalStatus=executed`
returns 
![image](https://user-images.githubusercontent.com/8763687/204584789-0a79656b-564e-47b2-a23e-dbb16e158d98.png)
