### PR TITLE
fix: Don't skip if data comes from the signature server

### DIFF
--- a/src/adapters/sources/rentals.ts
+++ b/src/adapters/sources/rentals.ts
@@ -80,12 +80,10 @@ export function createRentalsNFTSource(
     }
 
     const results = await rentals.getRentalsListings(filters)
-    const returningResult = {
+    return {
       data: await enhanceRentalListing(results.data.results),
       count: results.data.total,
     }
-
-    return returningResult
   }
 
   return {

--- a/src/adapters/sources/rentals.ts
+++ b/src/adapters/sources/rentals.ts
@@ -80,10 +80,12 @@ export function createRentalsNFTSource(
     }
 
     const results = await rentals.getRentalsListings(filters)
-    return {
+    const returningResult = {
       data: await enhanceRentalListing(results.data.results),
       count: results.data.total,
     }
+
+    return returningResult
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ import { createRentalsNFTComponent } from './ports/rentalNFTs/component'
 import {
   getLandAndEstateContractAddresses,
   rentalNFTComponentShouldFetch,
+  shouldFetch as shouldFetchRentalsFromSignatureServer,
 } from './logic/nfts/rentals'
 
 async function initComponents(): Promise<AppComponents> {
@@ -332,6 +333,8 @@ async function initComponents(): Promise<AppComponents> {
 
   const nfts = createMergerComponent<NFTResult, NFTFilters, NFTSortBy>({
     sources: nftSources,
+    shouldMergeResults: (options) =>
+      !shouldFetchRentalsFromSignatureServer(options),
     defaultSortBy: NFT_DEFAULT_SORT_BY,
     directions: {
       [NFTSortBy.CHEAPEST]: SortDirection.ASC,

--- a/src/ports/merger/component.ts
+++ b/src/ports/merger/component.ts
@@ -22,6 +22,7 @@ export function createMergerComponent<
     maxCount,
     mergerEqualFn,
     mergerStrategy,
+    shouldMergeResults,
   } = options
 
   function getOptionsWithDefaults(
@@ -121,10 +122,16 @@ export function createMergerComponent<
 
     const optionsWithDefaults = getOptionsWithDefaults(options)
 
-    const data = processFetchedData(
-      results.flatMap((result) => result.data),
-      optionsWithDefaults
-    )
+    const data =
+      shouldMergeResults && !shouldMergeResults(options)
+        ? results
+            .flatMap((result) => result.data)
+            .map((resultWrapper) => resultWrapper.result)
+        : processFetchedData(
+            results.flatMap((result) => result.data),
+            optionsWithDefaults
+          )
+
     const total = processCountData(results.map((results) => results.count))
 
     return { data, total }

--- a/src/ports/merger/types.ts
+++ b/src/ports/merger/types.ts
@@ -40,6 +40,7 @@ export type MergerOptions<
   maxCount?: number
   mergerStrategy?: (a: Result, b: Result) => Result
   mergerEqualFn?: (a: Result, b: Result) => boolean
+  shouldMergeResults?: (options: Options) => boolean
 }
 
 export namespace IMergerComponent {


### PR DESCRIPTION
The NFT server was skipping the data that comes from the signature server that only skips results by itself.
This PR removes the need to skip things if they're not needed.