### PR TITLE
fix: Order max rental price ascending

### DIFF
--- a/src/ports/rentals/components.ts
+++ b/src/ports/rentals/components.ts
@@ -80,10 +80,10 @@ export function createRentalsComponent(
         break
       case NFTSortBy.MAX_RENTAL_PRICE:
         parameters.sortBy = RentalsListingsSortBy.MAX_RENTAL_PRICE
-        parameters.sortDirection = RentalsListingSortDirection.DESC
+        parameters.sortDirection = RentalsListingSortDirection.ASC
         break
       case NFTSortBy.MIN_RENTAL_PRICE:
-        parameters.sortBy = RentalsListingsSortBy.MAX_RENTAL_PRICE
+        parameters.sortBy = RentalsListingsSortBy.MIN_RENTAL_PRICE
         parameters.sortDirection = RentalsListingSortDirection.ASC
         break
       case NFTSortBy.RENTAL_LISTING_DATE:

--- a/src/tests/ports/rentals.spec.ts
+++ b/src/tests/ports/rentals.spec.ts
@@ -189,7 +189,7 @@ describe('when getting rental listings', () => {
       expectedQueryParameters = {
         limit: filter.first,
         offset: filter.skip,
-        sortBy: RentalsListingsSortBy.MAX_RENTAL_PRICE,
+        sortBy: RentalsListingsSortBy.MIN_RENTAL_PRICE,
         sortDirection: RentalsListingSortDirection.ASC,
         category: (filter.category as unknown) as RentalsListingsFilterByCategory,
         lessor: filter.owner,


### PR DESCRIPTION
This PR changes the order of the NFT requested when requesting for the NFTs that have rentals ordered by max rental price. That is, ordered by the maximum value of their rental prices by day.
As of today, the maximum value of the rental price on all periods is the same as the minimum one, but we're using the maximum value everywhere due to the chance of someone registering the values manually.