### PR TITLE
fix: use gte and lte in price filter

### DIFF
--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -87,12 +87,12 @@ export function getFetchQuery(
 
   if (filters.maxPrice) {
     const maxPrice = ethers.utils.parseEther(filters.maxPrice).toString()
-    where.push(`searchOrderPrice_lt: "${maxPrice}"`)
+    where.push(`searchOrderPrice_lte: "${maxPrice}"`)
   }
 
   if (filters.minPrice) {
     const minPrice = ethers.utils.parseEther(filters.minPrice).toString()
-    where.push(`searchOrderPrice_gt: "${minPrice}"`)
+    where.push(`searchOrderPrice_gte: "${minPrice}"`)
   }
 
   if (filters.contractAddresses && filters.contractAddresses.length > 0) {


### PR DESCRIPTION
Use gte and lte for graphql query so that it also considers valid when the price is equal to the one send in params