### PR TITLE
fix: Throw bad request when no token id is provided

### DIFF
--- a/src/adapters/handlers/nfts.ts
+++ b/src/adapters/handlers/nfts.ts
@@ -64,8 +64,19 @@ export function createNFTsHandler(
     const maxPrice = params.getString('maxPrice')
     const minPrice = params.getString('minPrice')
 
-    return asJSON(() =>
-      nfts.fetchAndCount({
+    return asJSON(() => {
+      if (tokenId && !tokenId.match(`^[0-9]+$`)) {
+        throw new HttpError('Invalid token id, token ids must be numbers', 400)
+      }
+
+      if (tokenId && contractAddresses.length === 0) {
+        throw new HttpError(
+          "NFTs can't be queried by token id if no contract address is provided",
+          400
+        )
+      }
+
+      return nfts.fetchAndCount({
         first,
         skip,
         sortBy,
@@ -92,7 +103,7 @@ export function createNFTsHandler(
         maxPrice,
         minPrice,
       })
-    )
+    })
   }
 }
 

--- a/src/logic/nfts/collections.ts
+++ b/src/logic/nfts/collections.ts
@@ -7,6 +7,7 @@ import {
   NFTFilters,
   NFTSortBy,
   Rarity,
+  RentalStatus,
   WearableCategory,
 } from '@dcl/schemas'
 import { FragmentItemType } from '../../ports/items/types'
@@ -250,6 +251,9 @@ export function getCollectionsExtraWhere(options: NFTFilters) {
 
 export function collectionsShouldFetch(filters: NFTFilters) {
   if (
+    (Array.isArray(filters.rentalStatus) &&
+      (filters.rentalStatus as RentalStatus[]).length > 0) ||
+    (!Array.isArray(filters.rentalStatus) && filters.rentalStatus) ||
     filters.isLand ||
     (filters.network && filters.network !== Network.MATIC) ||
     (filters.category &&

--- a/src/ports/nfts/component.ts
+++ b/src/ports/nfts/component.ts
@@ -46,7 +46,17 @@ export function createNFTComponent<T extends { id: string }>(options: {
   }
 
   async function fetch(options: NFTFilters): Promise<NFTResult[]> {
-    if (options.tokenId && options.contractAddresses) {
+    if (
+      options.tokenId &&
+      options.contractAddresses &&
+      options.contractAddresses.length > 0
+    ) {
+      console.log(
+        'Fetch: Going to fetch one',
+        options.contractAddresses,
+        options.tokenId,
+        fragmentName
+      )
       const nft = await fetchOne(options.contractAddresses[0], options.tokenId)
       return nft ? [nft] : []
     } else if (options.tokenId) {

--- a/src/ports/nfts/component.ts
+++ b/src/ports/nfts/component.ts
@@ -51,12 +51,6 @@ export function createNFTComponent<T extends { id: string }>(options: {
       options.contractAddresses &&
       options.contractAddresses.length > 0
     ) {
-      console.log(
-        'Fetch: Going to fetch one',
-        options.contractAddresses,
-        options.tokenId,
-        fragmentName
-      )
       const nft = await fetchOne(options.contractAddresses[0], options.tokenId)
       return nft ? [nft] : []
     } else if (options.tokenId) {


### PR DESCRIPTION
This fixes two things:
- Prevents a query to be made to the graph is the token id is invalid or if the token id is set but there's no contract address for it.
- Prevents a collections query to be performed when requesting rented land with a rental status.