### PR TITLE
feat: add ability to filter by multiple play modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ type Item = {
 - `emotePlayMode`: Filter results by `EmotePlayMode`. Possible values: `simple`, `loop`
 - `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `itemId`: Filter results by `itemId`. Type: `string`.
+- `minPrice`: Return only sales with a price higher than this. Type `number`.
+- `maxPrice`: Return only sales with a price lower than this. Type `number`.
 - `network`: Filter results by `Network`. Possible values: `ETHEREUM`, `MATIC`.
 
 ## Orders

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ type Item = {
 - `wearableGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
 - `emoteCategory`: Filter results by `EmoteCategory`. Possible values: `dance`, `stunt`, `greetings`, `fun`, `poses`, `reactions`, `horror`, `miscellaneous`.
 - `emoteGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
-- `emotePlayMode`: Filter results by `EmotePlayMode`. Possible values: `simple`, `loop`
+- `emotePlayMode`: Filter results by `EmotePlayMode`. It supports multiple values by adding the query param multiple times. Possible values: `simple`, `loop`
 - `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `itemId`: Filter results by `itemId`. Type: `string`.
 - `minPrice`: Return only sales with a price higher than this. Type `number`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^5.32.0",
+        "@dcl/schemas": "^6.0.1",
         "@types/sqlite3": "^3.1.7",
         "@well-known-components/env-config-provider": "^1.1.1",
         "@well-known-components/http-server": "^1.1.6",
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.32.0.tgz",
-      "integrity": "sha512-irvdF66dQMqKfjYib9gINxgGTJWL3NAG2m8ujIctDiRnjpoPpzH2VCPjOj+IKpNjWbMth4XaGr1JO0sfJweseA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.0.1.tgz",
+      "integrity": "sha512-f2Y75tRQQs8DuaU2FFh/N5QnXQtw7yTRyBh/tJb0jPWgs8V1nC4SHdUyleykl3d/afPWf1kT8pWvsJBEOaWi0A==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -10881,9 +10881,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.32.0.tgz",
-      "integrity": "sha512-irvdF66dQMqKfjYib9gINxgGTJWL3NAG2m8ujIctDiRnjpoPpzH2VCPjOj+IKpNjWbMth4XaGr1JO0sfJweseA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.0.1.tgz",
+      "integrity": "sha512-f2Y75tRQQs8DuaU2FFh/N5QnXQtw7yTRyBh/tJb0jPWgs8V1nC4SHdUyleykl3d/afPWf1kT8pWvsJBEOaWi0A==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^5.31.0",
+        "@dcl/schemas": "^5.32.0",
         "@types/sqlite3": "^3.1.7",
         "@well-known-components/env-config-provider": "^1.1.1",
         "@well-known-components/http-server": "^1.1.6",
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.31.0.tgz",
-      "integrity": "sha512-hptlcPSUWtYgtbXaMYs/znlh1LLb2snBNJYc1u0Ng4wBs4XdpyEN1kgSAsNWUl4XmX5NSoW8t24E+fJ5BjWQIA==",
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.32.0.tgz",
+      "integrity": "sha512-irvdF66dQMqKfjYib9gINxgGTJWL3NAG2m8ujIctDiRnjpoPpzH2VCPjOj+IKpNjWbMth4XaGr1JO0sfJweseA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -10881,9 +10881,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.31.0.tgz",
-      "integrity": "sha512-hptlcPSUWtYgtbXaMYs/znlh1LLb2snBNJYc1u0Ng4wBs4XdpyEN1kgSAsNWUl4XmX5NSoW8t24E+fJ5BjWQIA==",
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.32.0.tgz",
+      "integrity": "sha512-irvdF66dQMqKfjYib9gINxgGTJWL3NAG2m8ujIctDiRnjpoPpzH2VCPjOj+IKpNjWbMth4XaGr1JO0sfJweseA==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "printWidth": 80
   },
   "dependencies": {
-    "@dcl/schemas": "^5.32.0",
+    "@dcl/schemas": "^6.0.1",
     "@types/sqlite3": "^3.1.7",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/http-server": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "printWidth": 80
   },
   "dependencies": {
-    "@dcl/schemas": "^5.31.0",
+    "@dcl/schemas": "^5.32.0",
     "@types/sqlite3": "^3.1.7",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/http-server": "^1.1.6",

--- a/src/adapters/handlers/items.ts
+++ b/src/adapters/handlers/items.ts
@@ -48,7 +48,7 @@ export function createItemsHandler(
       'emoteGender',
       WearableGender
     )
-    const emotePlayMode = params.getValue<EmotePlayMode>(
+    const emotePlayMode = params.getList<EmotePlayMode>(
       'emotePlayMode',
       EmotePlayMode
     )

--- a/src/adapters/handlers/items.ts
+++ b/src/adapters/handlers/items.ts
@@ -55,6 +55,8 @@ export function createItemsHandler(
     const contractAddresses = params.getList('contractAddress')
     const itemId = params.getString('itemId')
     const network = params.getValue<Network>('network', Network)
+    const maxPrice = params.getString('maxPrice')
+    const minPrice = params.getString('minPrice')
 
     return asJSON(() =>
       items.fetchAndCount({
@@ -78,6 +80,8 @@ export function createItemsHandler(
         itemId,
         isWearableSmart,
         network,
+        minPrice,
+        maxPrice
       })
     )
   }

--- a/src/adapters/handlers/nfts.ts
+++ b/src/adapters/handlers/nfts.ts
@@ -49,7 +49,7 @@ export function createNFTsHandler(
       'emoteGender',
       WearableGender
     )
-    const emotePlayMode = params.getValue<EmotePlayMode>(
+    const emotePlayMode = params.getList<EmotePlayMode>(
       'emotePlayMode',
       EmotePlayMode
     )

--- a/src/ports/items/utils.spec.ts
+++ b/src/ports/items/utils.spec.ts
@@ -1,3 +1,4 @@
+import { EmotePlayMode } from '@dcl/schemas';
 import { getItemsQuery } from './utils';
 
 describe("#getItemsQuery", () => {
@@ -10,6 +11,24 @@ describe("#getItemsQuery", () => {
   describe("when maxPrice is defined", () => {
     it("should add price filter to the query in wei", () => {
       expect(getItemsQuery({ maxPrice: '0.05' })).toEqual(expect.stringContaining('price_lte: "50000000000000000"'))
+    })
+  })
+
+  describe("when emotePlayMode is defined", () => {
+    describe("and it only has one property", () => {
+      it("should add loop as true to the query for LOOP mode", () => {
+        expect(getItemsQuery({ emotePlayMode: [EmotePlayMode.LOOP] })).toEqual(expect.stringContaining('searchEmoteLoop: true'))
+      })
+
+      it("should add loop as true to the query for SIMPLE mode", () => {
+        expect(getItemsQuery({ emotePlayMode: [EmotePlayMode.SIMPLE] })).toEqual(expect.stringContaining('searchEmoteLoop: false'))
+      })
+    })
+
+    describe("and it has more than one property", () => {
+      it("should not add loop filter to the query", () => {
+        expect(getItemsQuery({ emotePlayMode: [EmotePlayMode.LOOP, EmotePlayMode.SIMPLE] })).toEqual(expect.not.stringContaining('searchEmoteLoop'))
+      })
     })
   })
 });

--- a/src/ports/items/utils.spec.ts
+++ b/src/ports/items/utils.spec.ts
@@ -1,0 +1,15 @@
+import { getItemsQuery } from './utils';
+
+describe("#getItemsQuery", () => {
+  describe("when minPrice is defined", () => {
+    it("should add price filter to the query in wei", () => {
+      expect(getItemsQuery({ minPrice: '0.05' })).toEqual(expect.stringContaining('price_gte: "50000000000000000"'))
+    })
+  });
+
+  describe("when maxPrice is defined", () => {
+    it("should add price filter to the query in wei", () => {
+      expect(getItemsQuery({ maxPrice: '0.05' })).toEqual(expect.stringContaining('price_lte: "50000000000000000"'))
+    })
+  })
+});

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -283,6 +283,11 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
       }
     }
 
+    /**
+     * If emotePlayMode length is more than 1 we are ignoring the filter. This is done like this because
+     * we are now saving the playMode as a boolean in the graph (loop), so 2 properties means we want all items
+     * This should change when we add more play mode types.
+     */
     if (emotePlayMode && emotePlayMode.length === 1) {
       where.push(
         `searchEmoteLoop: ${emotePlayMode[0] === EmotePlayMode.LOOP}`

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -150,7 +150,8 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     contractAddresses,
     itemId,
     minPrice,
-    maxPrice
+    maxPrice,
+    emotePlayMode
   } = filters as ItemFilters
 
   const where: string[] = [`searchIsCollectionApproved: true`]
@@ -282,9 +283,9 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
       }
     }
 
-    if (filters.emotePlayMode) {
+    if (emotePlayMode && emotePlayMode.length === 1) {
       where.push(
-        `searchEmoteLoop: ${filters.emotePlayMode === EmotePlayMode.LOOP}`
+        `searchEmoteLoop: ${emotePlayMode[0] === EmotePlayMode.LOOP}`
       )
     }
 

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -1,4 +1,5 @@
 import BN from 'bn.js'
+import { ethers } from 'ethers'
 import {
   ChainId,
   EmotePlayMode,
@@ -148,6 +149,8 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     emoteGenders,
     contractAddresses,
     itemId,
+    minPrice,
+    maxPrice
   } = filters as ItemFilters
 
   const where: string[] = [`searchIsCollectionApproved: true`]
@@ -190,6 +193,16 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
 
   if (search) {
     where.push(`searchText_contains: "${search.trim().toLowerCase()}"`)
+  }
+
+  if (maxPrice) {
+    const maxPriceWei = ethers.utils.parseEther(maxPrice).toString()
+    where.push(`price_lte: "${maxPriceWei}"`)
+  }
+
+  if (minPrice) {
+    const minPriceWei = ethers.utils.parseEther(minPrice).toString()
+    where.push(`price_gte: "${minPriceWei}"`)
   }
 
   if (contractAddresses && contractAddresses.length > 0) {

--- a/src/ports/nfts/utils.spec.ts
+++ b/src/ports/nfts/utils.spec.ts
@@ -1,0 +1,22 @@
+import { EmotePlayMode } from '@dcl/schemas';
+import { getFetchQuery } from './utils';
+
+describe("#getItemsQuery", () => {
+  describe("when emotePlayMode is defined", () => {
+    describe("and it only has one property", () => {
+      it("should add loop as true to the query for LOOP mode", () => {
+        expect(getFetchQuery({ emotePlayMode: [EmotePlayMode.LOOP] }, '', () => '')).toEqual(expect.stringContaining('searchEmoteLoop: true'))
+      })
+
+      it("should add loop as true to the query for SIMPLE mode", () => {
+        expect(getFetchQuery({ emotePlayMode: [EmotePlayMode.SIMPLE] }, '', () => '')).toEqual(expect.stringContaining('searchEmoteLoop: false'))
+      })
+    })
+
+    describe("and it has more than one property", () => {
+      it("should not add loop filter to the query", () => {
+        expect(getFetchQuery({ emotePlayMode: [EmotePlayMode.LOOP, EmotePlayMode.SIMPLE] }, '', () => '')).toEqual(expect.not.stringContaining('searchEmoteLoop'))
+      })
+    })
+  })
+});

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -163,7 +163,12 @@ export function getFetchQuery(
         where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
       }
     }
-
+  
+    /**
+     * If emotePlayMode length is more than 1 we are ignoring the filter. This is done like this because
+     * we are now saving the playMode as a boolean in the graph (loop), so 2 properties means we want all items
+     * This should change when we add more play mode types.
+     */
     if (filters.emotePlayMode && filters.emotePlayMode.length === 1) {
       where.push(
         `searchEmoteLoop: ${filters.emotePlayMode[0] === EmotePlayMode.LOOP}`

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -164,9 +164,9 @@ export function getFetchQuery(
       }
     }
 
-    if (filters.emotePlayMode) {
+    if (filters.emotePlayMode && filters.emotePlayMode.length === 1) {
       where.push(
-        `searchEmoteLoop: ${filters.emotePlayMode === EmotePlayMode.LOOP}`
+        `searchEmoteLoop: ${filters.emotePlayMode[0] === EmotePlayMode.LOOP}`
       )
     }
 


### PR DESCRIPTION
Change logic to allow multiple play modes and not just one. Playmode is now being saved in the graph as a boolean (`loop`) but the idea is that in the future there will be more playmodes. So the logic is:
- `?emotePlayMode=simple` searches all items with `loop=false` in the graph
- `?emotePlayMode=loop` searches all items with `loop=true` in the graph
- `?emotePlayMode=loop&emotePlayMode=simple` will bring all `loop=true` and `loop=false` (the same as is the filter is not sent