### PR TITLE
feat: add unisex option to body filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ type Item = {
 - `wearableGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`, `unisex`.
 - `emoteCategory`: Filter results by `EmoteCategory`. Possible values: `dance`, `stunt`, `greetings`, `fun`, `poses`, `reactions`, `horror`, `miscellaneous`.
 - `emoteGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`, `unisex`.
-- `emotePlayMode`: Filter results by `EmotePlayMode`. It supports multiple values by adding the query param multiple times. Possible values: `simple`, `loop`,
+- `emotePlayMode`: Filter results by `EmotePlayMode`. It supports multiple values by adding the query param multiple times. Possible values: `simple`, `loop`
 - `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `itemId`: Filter results by `itemId`. Type: `string`.
 - `minPrice`: Return only sales with a price higher than this. Type `number`.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ type NFT = {
 - `isWearableAccessory`: Only return results that their category is `wearable` and accessories (not a part of the body).
 - `isWearableSmart`: Only return smart wearables. Type `boolean`.
 - `wearableCategory`: Filter results by `WearableCategory`. Possible values: `eyebrows`,`eyes`,`facial_hair`,`hair`,`mouth`,`upper_body`,`lower_body`,`feet`,`earring`,`eyewear`,`hat`,`helmet`,`mask`,`tiara`,`top_head`, `skin`.
-- `wearableGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
+- `wearableGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`, `unisex`.
 - `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `tokenId`: Filter results by `tokenId`. Type: `string`.
 - `itemRarity`: Filter results by `Rarity`. It supports multiple values by adding the query param multiple times. Possible values: `unique`, `mythic`, `legendary`, `epic`, `rare`, `uncommon`, `common`.
@@ -117,10 +117,10 @@ type Item = {
 - `isWearableAccessory`: Only return results that their category is `wearable` and accessories (not a part of the body).
 - `isWearableSmart`: Only return smart wearables. Type `boolean`.
 - `wearableCategory`: Filter results by `WearableCategory`. Possible values: `eyebrows`,`eyes`,`facial_hair`,`hair`,`mouth`,`upper_body`,`lower_body`,`feet`,`earring`,`eyewear`,`hat`,`helmet`,`mask`,`tiara`,`top_head`, `skin`.
-- `wearableGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
+- `wearableGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`, `unisex`.
 - `emoteCategory`: Filter results by `EmoteCategory`. Possible values: `dance`, `stunt`, `greetings`, `fun`, `poses`, `reactions`, `horror`, `miscellaneous`.
-- `emoteGender`: Filter results by `WearableGender`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`.
-- `emotePlayMode`: Filter results by `EmotePlayMode`. It supports multiple values by adding the query param multiple times. Possible values: `simple`, `loop`
+- `emoteGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female` `unisex`.
+- `emotePlayMode`: Filter results by `EmotePlayMode`. It supports multiple values by adding the query param multiple times. Possible values: `simple`, `loop`,
 - `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `itemId`: Filter results by `itemId`. Type: `string`.
 - `minPrice`: Return only sales with a price higher than this. Type `number`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ type Item = {
 - `wearableCategory`: Filter results by `WearableCategory`. Possible values: `eyebrows`,`eyes`,`facial_hair`,`hair`,`mouth`,`upper_body`,`lower_body`,`feet`,`earring`,`eyewear`,`hat`,`helmet`,`mask`,`tiara`,`top_head`, `skin`.
 - `wearableGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`, `unisex`.
 - `emoteCategory`: Filter results by `EmoteCategory`. Possible values: `dance`, `stunt`, `greetings`, `fun`, `poses`, `reactions`, `horror`, `miscellaneous`.
-- `emoteGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female` `unisex`.
+- `emoteGender`: Filter results by `GenderFilterOption`. It supports multiple values by adding the query param multiple times. Possible values: `male`, `female`, `unisex`.
 - `emotePlayMode`: Filter results by `EmotePlayMode`. It supports multiple values by adding the query param multiple times. Possible values: `simple`, `loop`,
 - `contractAddress`: Filter results by contract address. It supports multiple values by adding the query param multiple times. Type: `address`.
 - `itemId`: Filter results by `itemId`. Type: `string`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^6.0.1",
+        "@dcl/schemas": "^6.1.0",
         "@types/sqlite3": "^3.1.7",
         "@well-known-components/env-config-provider": "^1.1.1",
         "@well-known-components/http-server": "^1.1.6",
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.0.1.tgz",
-      "integrity": "sha512-f2Y75tRQQs8DuaU2FFh/N5QnXQtw7yTRyBh/tJb0jPWgs8V1nC4SHdUyleykl3d/afPWf1kT8pWvsJBEOaWi0A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.1.0.tgz",
+      "integrity": "sha512-mYDD9mYsRbA4ivOBLdVBImWPcOe3r+OzOfaeLMgPwPOc07Il8CSck3jE06plE3Lr0RGvxX80fOt3NIvRNGWXsQ==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -10881,9 +10881,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.0.1.tgz",
-      "integrity": "sha512-f2Y75tRQQs8DuaU2FFh/N5QnXQtw7yTRyBh/tJb0jPWgs8V1nC4SHdUyleykl3d/afPWf1kT8pWvsJBEOaWi0A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.1.0.tgz",
+      "integrity": "sha512-mYDD9mYsRbA4ivOBLdVBImWPcOe3r+OzOfaeLMgPwPOc07Il8CSck3jE06plE3Lr0RGvxX80fOt3NIvRNGWXsQ==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "printWidth": 80
   },
   "dependencies": {
-    "@dcl/schemas": "^6.0.1",
+    "@dcl/schemas": "^6.1.0",
     "@types/sqlite3": "^3.1.7",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/http-server": "^1.1.6",

--- a/src/adapters/handlers/items.ts
+++ b/src/adapters/handlers/items.ts
@@ -1,12 +1,12 @@
 import {
   EmoteCategory,
   EmotePlayMode,
+  GenderFilterOption,
   ItemSortBy,
   Network,
   NFTCategory,
   Rarity,
   WearableCategory,
-  WearableGender,
 } from '@dcl/schemas'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { AppComponents, Context } from '../../types'
@@ -36,17 +36,17 @@ export function createItemsHandler(
       WearableCategory
     )
     const rarities = params.getList<Rarity>('rarity', Rarity)
-    const wearableGenders = params.getList<WearableGender>(
+    const wearableGenders = params.getList<GenderFilterOption>(
       'wearableGender',
-      WearableGender
+      GenderFilterOption
     )
     const emoteCategory = params.getValue<EmoteCategory>(
       'emoteCategory',
       EmoteCategory
     )
-    const emoteGenders = params.getList<WearableGender>(
+    const emoteGenders = params.getList<GenderFilterOption>(
       'emoteGender',
-      WearableGender
+      GenderFilterOption
     )
     const emotePlayMode = params.getList<EmotePlayMode>(
       'emotePlayMode',
@@ -81,7 +81,7 @@ export function createItemsHandler(
         isWearableSmart,
         network,
         minPrice,
-        maxPrice
+        maxPrice,
       })
     )
   }

--- a/src/adapters/handlers/nfts.ts
+++ b/src/adapters/handlers/nfts.ts
@@ -1,13 +1,13 @@
 import {
   EmoteCategory,
   EmotePlayMode,
+  GenderFilterOption,
   Network,
   NFTCategory,
   NFTSortBy,
   Rarity,
   RentalStatus,
   WearableCategory,
-  WearableGender,
 } from '@dcl/schemas'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { AppComponents, Context } from '../../types'
@@ -37,17 +37,17 @@ export function createNFTsHandler(
       'wearableCategory',
       WearableCategory
     )
-    const wearableGenders = params.getList<WearableGender>(
+    const wearableGenders = params.getList<GenderFilterOption>(
       'wearableGender',
-      WearableGender
+      GenderFilterOption
     )
     const emoteCategory = params.getValue<EmoteCategory>(
       'emoteCategory',
       EmoteCategory
     )
-    const emoteGenders = params.getList<WearableGender>(
+    const emoteGenders = params.getList<GenderFilterOption>(
       'emoteGender',
-      WearableGender
+      GenderFilterOption
     )
     const emotePlayMode = params.getList<EmotePlayMode>(
       'emotePlayMode',

--- a/src/ports/items/utils.spec.ts
+++ b/src/ports/items/utils.spec.ts
@@ -1,4 +1,4 @@
-import { EmotePlayMode } from '@dcl/schemas';
+import { EmotePlayMode, GenderFilterOption } from '@dcl/schemas';
 import { getItemsQuery } from './utils';
 
 describe("#getItemsQuery", () => {
@@ -29,6 +29,50 @@ describe("#getItemsQuery", () => {
       it("should not add loop filter to the query", () => {
         expect(getItemsQuery({ emotePlayMode: [EmotePlayMode.LOOP, EmotePlayMode.SIMPLE] })).toEqual(expect.not.stringContaining('searchEmoteLoop'))
       })
+    })
+  })
+
+  describe("when emoteGenders is defined", () => {
+    it("should check searchEmoteBodyShapes is BaseFemale when gender is just female", () => {
+      expect(getItemsQuery({ emoteGenders: [GenderFilterOption.FEMALE] })).toEqual(expect.stringContaining('searchEmoteBodyShapes: [BaseFemale]'))
+    })
+
+    it("should check searchEmoteBodyShapes is BaseMale when gender is just male", () => {
+      expect(getItemsQuery({ emoteGenders: [GenderFilterOption.MALE] })).toEqual(expect.stringContaining('searchEmoteBodyShapes: [BaseMale]'))
+    })
+
+    it("should check searchEmoteBodyShapes contains BaseFemale when gender is female and unisex", () => {
+      expect(getItemsQuery({ emoteGenders: [GenderFilterOption.FEMALE, GenderFilterOption.UNISEX] })).toEqual(expect.stringContaining('searchEmoteBodyShapes_contains: [BaseFemale]'))
+    })
+
+    it("should check searchEmoteBodyShapes contains BaseMale when gender is male and unisex", () => {
+      expect(getItemsQuery({ emoteGenders: [GenderFilterOption.MALE, GenderFilterOption.UNISEX] })).toEqual(expect.stringContaining('searchEmoteBodyShapes_contains: [BaseMale]'))
+    })
+
+    it("should check searchEmoteBodyShapes contains BaseMale and BaseFemale when gender is unisex", () => {
+      expect(getItemsQuery({ emoteGenders: [GenderFilterOption.UNISEX] })).toEqual(expect.stringContaining('searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]'))
+    })
+  })
+
+  describe("when wearableGenders is defined", () => {
+    it("should check searchWearableBodyShapes is BaseFemale when gender is just female", () => {
+      expect(getItemsQuery({ wearableGenders: [GenderFilterOption.FEMALE] })).toEqual(expect.stringContaining('searchWearableBodyShapes: [BaseFemale]'))
+    })
+
+    it("should check searchWearableBodyShapes is BaseMale when gender is just male", () => {
+      expect(getItemsQuery({ wearableGenders: [GenderFilterOption.MALE] })).toEqual(expect.stringContaining('searchWearableBodyShapes: [BaseMale]'))
+    })
+
+    it("should check searchWearableBodyShapes contains BaseFemale when gender is female and unisex", () => {
+      expect(getItemsQuery({ wearableGenders: [GenderFilterOption.FEMALE, GenderFilterOption.UNISEX] })).toEqual(expect.stringContaining('searchWearableBodyShapes_contains: [BaseFemale]'))
+    })
+
+    it("should check searchWearableBodyShapes contains BaseMale when gender is male and unisex", () => {
+      expect(getItemsQuery({ wearableGenders: [GenderFilterOption.MALE, GenderFilterOption.UNISEX] })).toEqual(expect.stringContaining('searchWearableBodyShapes_contains: [BaseMale]'))
+    })
+
+    it("should check searchWearableBodyShapes contains BaseMale and BaseFemale when gender is unisex", () => {
+      expect(getItemsQuery({ wearableGenders: [GenderFilterOption.UNISEX] })).toEqual(expect.stringContaining('searchWearableBodyShapes_contains: [BaseMale, BaseFemale]'))
     })
   })
 });

--- a/src/ports/items/utils.ts
+++ b/src/ports/items/utils.ts
@@ -8,10 +8,10 @@ import {
   ItemSortBy,
   Network,
   NFTCategory,
-  GenderFilterOption,
 } from '@dcl/schemas'
 import { ItemFragment, FragmentItemType } from './types'
 import { isAddressZero } from '../../logic/address'
+import { getGenderFilterQuery } from '../utils'
 
 export const ITEM_DEFAULT_SORT_BY = ItemSortBy.NEWEST
 
@@ -240,30 +240,9 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     }
 
     if (wearableGenders && wearableGenders.length > 0) {
-      const hasMale = wearableGenders.includes(GenderFilterOption.MALE)
-      const hasFemale = wearableGenders.includes(GenderFilterOption.FEMALE)
-      const hasUnisex = wearableGenders.includes(GenderFilterOption.UNISEX)
-
-      if (wearableGenders.length === 1) {
-        if (hasMale) {
-          where.push(`searchWearableBodyShapes: [BaseMale]`)
-        } else if (hasFemale) {
-          where.push(`searchWearableBodyShapes: [BaseFemale]`)
-        } else if (hasUnisex) {
-          where.push(
-            `searchWearableBodyShapes_contains: [BaseMale, BaseFemale]`
-          )
-        }
-      } else if (wearableGenders.length === 2) {
-        if (hasMale && hasFemale) {
-          where.push(
-            `searchWearableBodyShapes_contains: [BaseMale, BaseFemale]`
-          )
-        } else if (hasMale && hasUnisex) {
-          where.push(`searchWearableBodyShapes_contains: [BaseMale]`)
-        } else {
-          where.push(`searchWearableBodyShapes_contains: [BaseFemale]`)
-        }
+      const genderQuery = getGenderFilterQuery(wearableGenders, false)
+      if (genderQuery) {
+        where.push(genderQuery)
       }
     }
 
@@ -286,26 +265,9 @@ export function getItemsQuery(filters: ItemFilters, isCount = false) {
     }
 
     if (emoteGenders && emoteGenders.length > 0) {
-      const hasMale = emoteGenders.includes(GenderFilterOption.MALE)
-      const hasFemale = emoteGenders.includes(GenderFilterOption.FEMALE)
-      const hasUnisex = emoteGenders.includes(GenderFilterOption.UNISEX)
-
-      if (emoteGenders.length === 1) {
-        if (hasMale) {
-          where.push(`searchEmoteBodyShapes: [BaseMale]`)
-        } else if (hasFemale) {
-          where.push(`searchEmoteBodyShapes: [BaseFemale]`)
-        } else if (hasUnisex) {
-          where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
-        }
-      } else if (emoteGenders.length === 2) {
-        if (hasMale && hasFemale) {
-          where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
-        } else if (hasMale && hasUnisex) {
-          where.push(`searchEmoteBodyShapes_contains: [BaseMale]`)
-        } else {
-          where.push(`searchEmoteBodyShapes_contains: [BaseFemale]`)
-        }
+      const genderQuery = getGenderFilterQuery(emoteGenders, true)
+      if (genderQuery) {
+        where.push(genderQuery)
       }
     }
 

--- a/src/ports/nfts/utils.spec.ts
+++ b/src/ports/nfts/utils.spec.ts
@@ -1,7 +1,7 @@
-import { EmotePlayMode } from '@dcl/schemas';
+import { EmotePlayMode, GenderFilterOption } from '@dcl/schemas';
 import { getFetchQuery } from './utils';
 
-describe("#getItemsQuery", () => {
+describe("#getFetchQuery", () => {
   describe("when emotePlayMode is defined", () => {
     describe("and it only has one property", () => {
       it("should add loop as true to the query for LOOP mode", () => {
@@ -17,6 +17,50 @@ describe("#getItemsQuery", () => {
       it("should not add loop filter to the query", () => {
         expect(getFetchQuery({ emotePlayMode: [EmotePlayMode.LOOP, EmotePlayMode.SIMPLE] }, '', () => '')).toEqual(expect.not.stringContaining('searchEmoteLoop'))
       })
+    })
+  })
+
+  describe("when emoteGenders is defined", () => {
+    it("should check searchEmoteBodyShapes is BaseFemale when gender is just female", () => {
+      expect(getFetchQuery({ emoteGenders: [GenderFilterOption.FEMALE] }, '', () => '')).toEqual(expect.stringContaining('searchEmoteBodyShapes: [BaseFemale]'))
+    })
+
+    it("should check searchEmoteBodyShapes is BaseMale when gender is just male", () => {
+      expect(getFetchQuery({ emoteGenders: [GenderFilterOption.MALE] }, '', () => '')).toEqual(expect.stringContaining('searchEmoteBodyShapes: [BaseMale]'))
+    })
+
+    it("should check searchEmoteBodyShapes contains BaseFemale when gender is female and unisex", () => {
+      expect(getFetchQuery({ emoteGenders: [GenderFilterOption.FEMALE, GenderFilterOption.UNISEX] }, '', () => '')).toEqual(expect.stringContaining('searchEmoteBodyShapes_contains: [BaseFemale]'))
+    })
+
+    it("should check searchEmoteBodyShapes contains BaseMale when gender is male and unisex", () => {
+      expect(getFetchQuery({ emoteGenders: [GenderFilterOption.MALE, GenderFilterOption.UNISEX] }, '', () => '')).toEqual(expect.stringContaining('searchEmoteBodyShapes_contains: [BaseMale]'))
+    })
+
+    it("should check searchEmoteBodyShapes contains BaseMale and BaseFemale when gender is unisex", () => {
+      expect(getFetchQuery({ emoteGenders: [GenderFilterOption.UNISEX] }, '', () => '')).toEqual(expect.stringContaining('searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]'))
+    })
+  })
+
+  describe("when wearableGenders is defined", () => {
+    it("should check searchWearableBodyShapes is BaseFemale when gender is just female", () => {
+      expect(getFetchQuery({ wearableGenders: [GenderFilterOption.FEMALE] }, '', () => '')).toEqual(expect.stringContaining('searchWearableBodyShapes: [BaseFemale]'))
+    })
+
+    it("should check searchWearableBodyShapes is BaseMale when gender is just male", () => {
+      expect(getFetchQuery({ wearableGenders: [GenderFilterOption.MALE] }, '', () => '')).toEqual(expect.stringContaining('searchWearableBodyShapes: [BaseMale]'))
+    })
+
+    it("should check searchWearableBodyShapes contains BaseFemale when gender is female and unisex", () => {
+      expect(getFetchQuery({ wearableGenders: [GenderFilterOption.FEMALE, GenderFilterOption.UNISEX] }, '', () => '')).toEqual(expect.stringContaining('searchWearableBodyShapes_contains: [BaseFemale]'))
+    })
+
+    it("should check searchWearableBodyShapes contains BaseMale when gender is male and unisex", () => {
+      expect(getFetchQuery({ wearableGenders: [GenderFilterOption.MALE, GenderFilterOption.UNISEX] }, '', () => '')).toEqual(expect.stringContaining('searchWearableBodyShapes_contains: [BaseMale]'))
+    })
+
+    it("should check searchWearableBodyShapes contains BaseMale and BaseFemale when gender is unisex", () => {
+      expect(getFetchQuery({ wearableGenders: [GenderFilterOption.UNISEX] }, '', () => '')).toEqual(expect.stringContaining('searchWearableBodyShapes_contains: [BaseMale, BaseFemale]'))
     })
   })
 });

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -3,9 +3,9 @@ import {
   NFTCategory,
   NFTFilters,
   NFTSortBy,
-  GenderFilterOption,
 } from '@dcl/schemas'
 import { ethers } from 'ethers'
+import { getGenderFilterQuery } from '../utils'
 import { QueryVariables } from './types'
 
 export const NFT_DEFAULT_SORT_BY = NFTSortBy.NEWEST
@@ -125,35 +125,8 @@ export function getFetchQuery(
     }
 
     if (filters.wearableGenders && filters.wearableGenders.length > 0) {
-      const hasMale = filters.wearableGenders.includes(GenderFilterOption.MALE)
-      const hasFemale = filters.wearableGenders.includes(
-        GenderFilterOption.FEMALE
-      )
-      const hasUnisex = filters.wearableGenders.includes(
-        GenderFilterOption.UNISEX
-      )
-
-      if (filters.wearableGenders.length === 1) {
-        if (hasMale) {
-          where.push(`searchWearableBodyShapes: [BaseMale]`)
-        } else if (hasFemale) {
-          where.push(`searchWearableBodyShapes: [BaseFemale]`)
-        } else if (hasUnisex) {
-          where.push(
-            `searchWearableBodyShapes_contains: [BaseMale, BaseFemale]`
-          )
-        }
-      } else if (filters.wearableGenders.length === 2) {
-        if (hasMale && hasFemale) {
-          where.push(
-            `searchWearableBodyShapes_contains: [BaseMale, BaseFemale]`
-          )
-        } else if (hasMale && hasUnisex) {
-          where.push(`searchWearableBodyShapes_contains: [BaseMale]`)
-        } else {
-          where.push(`searchWearableBodyShapes_contains: [BaseFemale]`)
-        }
-      }
+      const genderQuery = getGenderFilterQuery(filters.wearableGenders, false);
+      where.push(genderQuery)
     }
 
     if (filters.itemRarities && filters.itemRarities.length > 0) {
@@ -171,26 +144,9 @@ export function getFetchQuery(
     }
 
     if (filters.emoteGenders && filters.emoteGenders.length > 0) {
-      const hasMale = filters.emoteGenders.includes(GenderFilterOption.MALE)
-      const hasFemale = filters.emoteGenders.includes(GenderFilterOption.FEMALE)
-      const hasUnisex = filters.emoteGenders.includes(GenderFilterOption.UNISEX)
-
-      if (filters.emoteGenders.length === 1) {
-        if (hasMale) {
-          where.push(`searchEmoteBodyShapes: [BaseMale]`)
-        } else if (hasFemale) {
-          where.push(`searchEmoteBodyShapes: [BaseFemale]`)
-        } else if (hasUnisex) {
-          where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
-        }
-      } else if (filters.emoteGenders.length === 2) {
-        if (hasMale && hasFemale) {
-          where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
-        } else if (hasMale && hasUnisex) {
-          where.push(`searchEmoteBodyShapes_contains: [BaseMale]`)
-        } else {
-          where.push(`searchEmoteBodyShapes_contains: [BaseFemale]`)
-        }
+      const genderQuery = getGenderFilterQuery(filters.emoteGenders, true);
+      if (genderQuery) {
+        where.push(genderQuery)
       }
     }
 
@@ -223,7 +179,7 @@ export function getFetchQuery(
       ? filters.skip + filters.first
       : filters.first
     : max
-
+  
   const query = `query NFTs(
     ${NFTS_FILTERS}
     ${getExtraVariables ? getExtraVariables(filters).join('\n') : ''}

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -3,7 +3,7 @@ import {
   NFTCategory,
   NFTFilters,
   NFTSortBy,
-  WearableGender,
+  GenderFilterOption,
 } from '@dcl/schemas'
 import { ethers } from 'ethers'
 import { QueryVariables } from './types'
@@ -125,15 +125,34 @@ export function getFetchQuery(
     }
 
     if (filters.wearableGenders && filters.wearableGenders.length > 0) {
-      const hasMale = filters.wearableGenders.includes(WearableGender.MALE)
-      const hasFemale = filters.wearableGenders.includes(WearableGender.FEMALE)
+      const hasMale = filters.wearableGenders.includes(GenderFilterOption.MALE)
+      const hasFemale = filters.wearableGenders.includes(
+        GenderFilterOption.FEMALE
+      )
+      const hasUnisex = filters.wearableGenders.includes(
+        GenderFilterOption.UNISEX
+      )
 
-      if (hasMale && !hasFemale) {
-        where.push(`searchWearableBodyShapes: [BaseMale]`)
-      } else if (hasFemale && !hasMale) {
-        where.push(`searchWearableBodyShapes: [BaseFemale]`)
-      } else if (hasMale && hasFemale) {
-        where.push(`searchWearableBodyShapes_contains: [BaseMale, BaseFemale]`)
+      if (filters.wearableGenders.length === 1) {
+        if (hasMale) {
+          where.push(`searchWearableBodyShapes: [BaseMale]`)
+        } else if (hasFemale) {
+          where.push(`searchWearableBodyShapes: [BaseFemale]`)
+        } else if (hasUnisex) {
+          where.push(
+            `searchWearableBodyShapes_contains: [BaseMale, BaseFemale]`
+          )
+        }
+      } else if (filters.wearableGenders.length === 2) {
+        if (hasMale && hasFemale) {
+          where.push(
+            `searchWearableBodyShapes_contains: [BaseMale, BaseFemale]`
+          )
+        } else if (hasMale && hasUnisex) {
+          where.push(`searchWearableBodyShapes_contains: [BaseMale]`)
+        } else {
+          where.push(`searchWearableBodyShapes_contains: [BaseFemale]`)
+        }
       }
     }
 
@@ -152,18 +171,29 @@ export function getFetchQuery(
     }
 
     if (filters.emoteGenders && filters.emoteGenders.length > 0) {
-      const hasMale = filters.emoteGenders.includes(WearableGender.MALE)
-      const hasFemale = filters.emoteGenders.includes(WearableGender.FEMALE)
+      const hasMale = filters.emoteGenders.includes(GenderFilterOption.MALE)
+      const hasFemale = filters.emoteGenders.includes(GenderFilterOption.FEMALE)
+      const hasUnisex = filters.emoteGenders.includes(GenderFilterOption.UNISEX)
 
-      if (hasMale && !hasFemale) {
-        where.push(`searchEmoteBodyShapes: [BaseMale]`)
-      } else if (hasFemale && !hasMale) {
-        where.push(`searchEmoteBodyShapes: [BaseFemale]`)
-      } else if (hasMale && hasFemale) {
-        where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
+      if (filters.emoteGenders.length === 1) {
+        if (hasMale) {
+          where.push(`searchEmoteBodyShapes: [BaseMale]`)
+        } else if (hasFemale) {
+          where.push(`searchEmoteBodyShapes: [BaseFemale]`)
+        } else if (hasUnisex) {
+          where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
+        }
+      } else if (filters.emoteGenders.length === 2) {
+        if (hasMale && hasFemale) {
+          where.push(`searchEmoteBodyShapes_contains: [BaseMale, BaseFemale]`)
+        } else if (hasMale && hasUnisex) {
+          where.push(`searchEmoteBodyShapes_contains: [BaseMale]`)
+        } else {
+          where.push(`searchEmoteBodyShapes_contains: [BaseFemale]`)
+        }
       }
     }
-  
+
     /**
      * If emotePlayMode length is more than 1 we are ignoring the filter. This is done like this because
      * we are now saving the playMode as a boolean in the graph (loop), so 2 properties means we want all items

--- a/src/ports/utils.ts
+++ b/src/ports/utils.ts
@@ -1,0 +1,34 @@
+import { GenderFilterOption, WearableGender } from "@dcl/schemas";
+
+export function getGenderFilterQuery(genders: (WearableGender | GenderFilterOption)[], isEmote: boolean): string {
+  const hasMale = genders.includes(GenderFilterOption.MALE)
+  const hasFemale = genders.includes(GenderFilterOption.FEMALE)
+  const hasUnisex = genders.includes(GenderFilterOption.UNISEX)
+  const searchProperty = isEmote ? 'searchEmoteBodyShapes' : 'searchWearableBodyShapes';
+
+  if (genders.length === 1) {
+    if (hasMale) {
+      return `${searchProperty}: [BaseMale]`
+    }
+    
+    if (hasFemale) {
+      return `${searchProperty}: [BaseFemale]`
+    }
+    
+    return `${searchProperty}_contains: [BaseMale, BaseFemale]`
+  }
+  
+  if (genders.length === 2) {
+    if (hasMale && hasFemale) {
+      return `${searchProperty}_contains: [BaseMale, BaseFemale]`
+    }
+    
+    if (hasMale && hasUnisex) {
+      return `${searchProperty}_contains: [BaseMale]`
+    }
+    
+    return `${searchProperty}_contains: [BaseFemale]`
+  }
+
+  return ''
+}


### PR DESCRIPTION
Add unisex option to body shape filter. The options are:
- male (will bring all items|nfts that only have male as a bodyShape)
- female (will bring all items|nfts that only have female as a bodyShape)
- male_female (will bring all items|nfts that have male and female as a bodyShape)
- unisex (will bring all items|nfts that have male and female as a bodyShape)
- male_unisex (will bring all items|nfts that have male as a bodyShape. including the ones that have also female)
- female_unisex (will bring all items|nfts that have female as a bodyShape. including the ones that have also male)