### PR TITLE
fix: use "gte" operator to include rankings min date in the calculation

### DIFF
--- a/src/ports/rankings/utils.ts
+++ b/src/ports/rankings/utils.ts
@@ -71,7 +71,7 @@ function getQueryParams(entity: RankingEntity, filters: RankingsFilters) {
     }
   }
   if (from) {
-    where.push(`date_gt: ${Math.round(from / 1000)}`)
+    where.push(`date_gte: ${Math.round(from / 1000)}`)
   }
   let orderBy = 'volume'
   let orderDirection = 'desc'


### PR DESCRIPTION
Closes #240