### PR TITLE
fix: Update the http requests logger component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/schemas": "^6.12.0",
         "@well-known-components/env-config-provider": "^1.2.0",
-        "@well-known-components/http-requests-logger-component": "^2.0.0",
+        "@well-known-components/http-requests-logger-component": "^2.0.1",
         "@well-known-components/http-server": "^1.1.6",
         "@well-known-components/http-tracer-component": "^1.1.0",
         "@well-known-components/interfaces": "^1.2.0",
@@ -2618,9 +2618,9 @@
       }
     },
     "node_modules/@well-known-components/http-requests-logger-component": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@well-known-components/http-requests-logger-component/-/http-requests-logger-component-2.0.0.tgz",
-      "integrity": "sha512-2wdkU5Dc/Osm1nQ3RPwSLmYCyQNppfuts4lipoNLh+cPbsjDk1rPuy6UFXAbda5mxoTaJlR4TEnE48J8z/Bk7Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@well-known-components/http-requests-logger-component/-/http-requests-logger-component-2.0.1.tgz",
+      "integrity": "sha512-7KPOI3JiIC8XBICGxHS/hoGzCPYlfUoluIX2c4pqmMJ4lI/iG+NFv55lMSIFof68I6H8F3FWpv1eUQ/pIT5Cpw==",
       "dependencies": {
         "@well-known-components/interfaces": "^1.2.0",
         "tslib": "^2.5.0"
@@ -11526,9 +11526,9 @@
       }
     },
     "@well-known-components/http-requests-logger-component": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@well-known-components/http-requests-logger-component/-/http-requests-logger-component-2.0.0.tgz",
-      "integrity": "sha512-2wdkU5Dc/Osm1nQ3RPwSLmYCyQNppfuts4lipoNLh+cPbsjDk1rPuy6UFXAbda5mxoTaJlR4TEnE48J8z/Bk7Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@well-known-components/http-requests-logger-component/-/http-requests-logger-component-2.0.1.tgz",
+      "integrity": "sha512-7KPOI3JiIC8XBICGxHS/hoGzCPYlfUoluIX2c4pqmMJ4lI/iG+NFv55lMSIFof68I6H8F3FWpv1eUQ/pIT5Cpw==",
       "requires": {
         "@well-known-components/interfaces": "^1.2.0",
         "tslib": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@dcl/schemas": "^6.12.0",
     "@well-known-components/env-config-provider": "^1.2.0",
-    "@well-known-components/http-requests-logger-component": "^2.0.0",
+    "@well-known-components/http-requests-logger-component": "^2.0.1",
     "@well-known-components/http-server": "^1.1.6",
     "@well-known-components/http-tracer-component": "^1.1.0",
     "@well-known-components/interfaces": "^1.2.0",


### PR DESCRIPTION
This PR updates the http requests logger component so it doesn't log the `ready` requests.