### PR TITLE
fix: minPrice query price missing if the item is on sale

### DIFF
--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -177,11 +177,11 @@ export const getRaritiesWhere = (filters: CatalogFilters) => {
 }
 
 export const getMinPriceWhere = (filters: CatalogFilters) => {
-  return SQL`(min_price >= ${filters.minPrice} OR (price >= ${filters.minPrice} AND available > 0))`
+  return SQL`(min_price >= ${filters.minPrice} OR (price >= ${filters.minPrice} AND available > 0 AND search_is_store_minter = true))`
 }
 
 export const getMaxPriceWhere = (filters: CatalogFilters) => {
-  return SQL`(max_price <= ${filters.maxPrice} OR (price <= ${filters.maxPrice} AND available > 0))`
+  return SQL`(max_price <= ${filters.maxPrice} OR (price <= ${filters.maxPrice} AND available > 0 AND search_is_store_minter = true))`
 }
 
 export const getContractAddressWhere = (filters: CatalogFilters) => {

--- a/src/tests/ports/catalog-queries.spec.ts
+++ b/src/tests/ports/catalog-queries.spec.ts
@@ -203,7 +203,7 @@ test('catalog utils', function () {
       })
       it('should add the min price definition to the WHERE', () => {
         expect(getCollectionsQueryWhere(filters).text).toContain(
-          `(min_price >= $1 OR (price >= $2 AND available > 0))`
+          `(min_price >= $1 OR (price >= $2 AND available > 0 AND search_is_store_minter = true))`
         )
         expect(getCollectionsQueryWhere(filters).values).toStrictEqual([
           filters.minPrice,
@@ -222,7 +222,7 @@ test('catalog utils', function () {
       })
       it('should add the max price definition to the WHERE', () => {
         expect(getCollectionsQueryWhere(filters).text).toContain(
-          `(max_price <= $1 OR (price <= $2 AND available > 0))`
+          `(max_price <= $1 OR (price <= $2 AND available > 0 AND search_is_store_minter = true))`
         )
         expect(getCollectionsQueryWhere(filters).values).toStrictEqual([
           filters.maxPrice,


### PR DESCRIPTION
`search_is_store_minter` needs to be `true` for the item to be on sale, it was missing in the `WHERE` statement when applying a min price.