### PR TITLE
feat: add price range to the Orders JOIN to filter listings in that range

### DIFF
--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -177,7 +177,6 @@ export const getRaritiesWhere = (filters: CatalogFilters) => {
 }
 
 export const getOrderRangePriceWhere = (filters: CatalogFilters) => {
-  console.log('filters: ', filters)
   if (filters.minPrice && !filters.maxPrice) {
     return SQL`AND orders.price >= ${filters.minPrice}`
   } else if (!filters.minPrice && filters.maxPrice) {

--- a/src/tests/ports/catalog-queries.spec.ts
+++ b/src/tests/ports/catalog-queries.spec.ts
@@ -391,6 +391,7 @@ test('catalog utils', () => {
   })
 
   describe('when there is a prince range applied', () => {
+    let query: SQLStatement
     let filters: CatalogFilters
     let minPrice: string
     let maxPrice: string
@@ -400,20 +401,12 @@ test('catalog utils', () => {
         filters = {
           minPrice,
         }
+        query = getCollectionsItemsCatalogQuery('aSchemaVersion', filters)
       })
       it('should apply the range to the orders table JOIN', () => {
-        expect(
-          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
-        ).toContain(`AND orders.price >= $`)
-        expect(
-          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
-        ).not.toContain(`AND orders.price <= $`)
-        expect(
-          getCollectionsItemsCatalogQuery(
-            'aSchemaVersion',
-            filters
-          ).values.includes(minPrice)
-        ).toBe(true)
+        expect(query.text).toContain(`AND orders.price >= $`)
+        expect(query.text).not.toContain(`AND orders.price <= $`)
+        expect(query.values.includes(minPrice)).toBe(true)
       })
     })
     describe('and there is only max price applied', () => {
@@ -422,20 +415,12 @@ test('catalog utils', () => {
         filters = {
           maxPrice,
         }
+        query = getCollectionsItemsCatalogQuery('aSchemaVersion', filters)
       })
       it('should apply the range to the orders table JOIN', () => {
-        expect(
-          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
-        ).toContain(`AND orders.price <= $`)
-        expect(
-          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
-        ).not.toContain(`AND orders.price >= $`)
-        expect(
-          getCollectionsItemsCatalogQuery(
-            'aSchemaVersion',
-            filters
-          ).values.includes(maxPrice)
-        ).toBe(true)
+        expect(query.text).toContain(`AND orders.price <= $`)
+        expect(query).not.toContain(`AND orders.price >= $`)
+        expect(query.values.includes(maxPrice)).toBe(true)
       })
     })
     describe('and has both min and prices applied', () => {
@@ -446,26 +431,13 @@ test('catalog utils', () => {
           minPrice,
           maxPrice,
         }
+        query = getCollectionsItemsCatalogQuery('aSchemaVersion', filters)
       })
       it('should apply the range to the orders table JOIN', () => {
-        expect(
-          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
-        ).toContain(`AND orders.price <= $`)
-        expect(
-          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
-        ).toContain(`AND orders.price >= $`)
-        expect(
-          getCollectionsItemsCatalogQuery(
-            'aSchemaVersion',
-            filters
-          ).values.includes(minPrice)
-        ).toBe(true)
-        expect(
-          getCollectionsItemsCatalogQuery(
-            'aSchemaVersion',
-            filters
-          ).values.includes(maxPrice)
-        ).toBe(true)
+        expect(query.text).toContain(`AND orders.price <= $`)
+        expect(query.text).toContain(`AND orders.price >= $`)
+        expect(query.values.includes(minPrice)).toBe(true)
+        expect(query.values.includes(maxPrice)).toBe(true)
       })
     })
   })

--- a/src/tests/ports/catalog-queries.spec.ts
+++ b/src/tests/ports/catalog-queries.spec.ts
@@ -11,6 +11,7 @@ import {
 import {
   addQueryPagination,
   addQuerySort,
+  getCollectionsItemsCatalogQuery,
   getCollectionsQueryWhere,
   getLatestSubgraphSchema,
   getOrderBy,
@@ -18,7 +19,7 @@ import {
 import { FragmentItemType } from '../../ports/items/types'
 import { test } from '../components'
 
-test('catalog utils', function () {
+test('catalog utils', () => {
   describe('when getting the latest subgraph schema by subgraph name', () => {
     let subgrahName = 'collections-matic'
     it('should contain the subgraph name asked as part of the query values', () => {
@@ -386,6 +387,86 @@ test('catalog utils', function () {
       addQueryPagination(query, { offset, limit })
       expect(query.text).toBe(`LIMIT $1 OFFSET $2`)
       expect(query.values).toStrictEqual([limit, offset])
+    })
+  })
+
+  describe('when there is a prince range applied', () => {
+    let filters: CatalogFilters
+    let minPrice: string
+    let maxPrice: string
+    describe('and there is only min price applied', () => {
+      beforeEach(() => {
+        minPrice = '10'
+        filters = {
+          minPrice,
+        }
+      })
+      it('should apply the range to the orders table JOIN', () => {
+        expect(
+          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
+        ).toContain(`AND orders.price >= $`)
+        expect(
+          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
+        ).not.toContain(`AND orders.price <= $`)
+        expect(
+          getCollectionsItemsCatalogQuery(
+            'aSchemaVersion',
+            filters
+          ).values.includes(minPrice)
+        ).toBe(true)
+      })
+    })
+    describe('and there is only max price applied', () => {
+      beforeEach(() => {
+        maxPrice = '100'
+        filters = {
+          maxPrice,
+        }
+      })
+      it('should apply the range to the orders table JOIN', () => {
+        expect(
+          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
+        ).toContain(`AND orders.price <= $`)
+        expect(
+          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
+        ).not.toContain(`AND orders.price >= $`)
+        expect(
+          getCollectionsItemsCatalogQuery(
+            'aSchemaVersion',
+            filters
+          ).values.includes(maxPrice)
+        ).toBe(true)
+      })
+    })
+    describe('and has both min and prices applied', () => {
+      beforeEach(() => {
+        minPrice = '10'
+        maxPrice = '100'
+        filters = {
+          minPrice,
+          maxPrice,
+        }
+      })
+      it('should apply the range to the orders table JOIN', () => {
+        expect(
+          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
+        ).toContain(`AND orders.price <= $`)
+        expect(
+          getCollectionsItemsCatalogQuery('aSchemaVersion', filters).text
+        ).toContain(`AND orders.price >= $`)
+        expect(
+          getCollectionsItemsCatalogQuery(
+            'aSchemaVersion',
+            filters
+          ).values.includes(minPrice)
+        ).toBe(true)
+        expect(
+          getCollectionsItemsCatalogQuery(
+            'aSchemaVersion',
+            filters
+          ).values.includes(maxPrice)
+        ).toBe(true)
+      })
     })
   })
 })


### PR DESCRIPTION
The frontend needs to know about the listings in the range if it's applied. Adding the `WHERE` conditions in the orders JOIN will do the job.