### PR TITLE
fix: add MIN and MAX price filters in CASE for min_price and max_price

### DIFF
--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -265,6 +265,28 @@ const getOwnersJoin = (schemaVersion: string) => {
     )
 }
 
+const getMinPriceCase = (filters: CatalogQueryFilters) => {
+  return SQL`CASE
+                WHEN items.available > 0 AND items.search_is_store_minter = true 
+                `.append(
+    filters.minPrice ? SQL`AND items.price >= ${filters.minPrice}` : SQL``
+  ).append(` THEN LEAST(items.price, nfts_with_orders.min_price) 
+                ELSE nfts_with_orders.min_price 
+              END AS min_price
+            `)
+}
+
+const getMaxPriceCase = (filters: CatalogQueryFilters) => {
+  return SQL`CASE
+                WHEN available > 0 AND items.search_is_store_minter = true 
+                `.append(
+    filters.maxPrice ? SQL`AND items.price <= ${filters.maxPrice}` : SQL``
+  ).append(` THEN GREATEST(items.price, nfts_with_orders.max_price)
+          ELSE nfts_with_orders.max_price 
+          END AS max_price
+          `)
+}
+
 export const getCollectionsItemsCatalogQuery = (
   schemaVersion: string,
   filters: CatalogQueryFilters
@@ -304,14 +326,16 @@ export const getCollectionsItemsCatalogQuery = (
     .append(
       `
               nfts_with_orders.max_order_created_at as max_order_created_at,
-              CASE
-                WHEN items.available > 0 AND items.search_is_store_minter = true THEN LEAST(items.price, nfts_with_orders.min_price) 
-                ELSE nfts_with_orders.min_price 
-              END AS min_price,
-              CASE 
-                WHEN available > 0 AND items.search_is_store_minter = true THEN GREATEST(items.price, nfts_with_orders.max_price) 
-                ELSE nfts_with_orders.max_price END
-             AS max_price
+              `
+    )
+    .append(getMinPriceCase(filters))
+    .append(
+      `,
+              `
+    )
+    .append(getMaxPriceCase(filters))
+    .append(
+      `
             FROM `
     )
     .append(schemaVersion)

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -278,7 +278,7 @@ const getMinPriceCase = (filters: CatalogQueryFilters) => {
 
 const getMaxPriceCase = (filters: CatalogQueryFilters) => {
   return SQL`CASE
-                WHEN available > 0 AND items.search_is_store_minter = true 
+                WHEN items.available > 0 AND items.search_is_store_minter = true 
                 `.append(
     filters.maxPrice ? SQL`AND items.price <= ${filters.maxPrice}` : SQL``
   ).append(` THEN GREATEST(items.price, nfts_with_orders.max_price)

--- a/src/tests/ports/catalog-queries.spec.ts
+++ b/src/tests/ports/catalog-queries.spec.ts
@@ -404,7 +404,11 @@ test('catalog utils', () => {
         query = getCollectionsItemsCatalogQuery('aSchemaVersion', filters)
       })
       it('should apply the range to the orders table JOIN', () => {
+        const queryTextFormatted = query.text.replace(/\s+/g, ' ')
         expect(query.text).toContain(`AND orders.price >= $`)
+        expect(queryTextFormatted).toContain(
+          `CASE WHEN items.available > 0 AND items.search_is_store_minter = true AND items.price >= $2 THEN LEAST(items.price, nfts_with_orders.min_price) ELSE nfts_with_orders.min_price END AS min_price`
+        )
         expect(query.text).not.toContain(`AND orders.price <= $`)
         expect(query.values.includes(minPrice)).toBe(true)
       })
@@ -418,7 +422,11 @@ test('catalog utils', () => {
         query = getCollectionsItemsCatalogQuery('aSchemaVersion', filters)
       })
       it('should apply the range to the orders table JOIN', () => {
+        const queryTextFormatted = query.text.replace(/\s+/g, ' ')
         expect(query.text).toContain(`AND orders.price <= $`)
+        expect(queryTextFormatted).toContain(
+          `CASE WHEN available > 0 AND items.search_is_store_minter = true AND items.price <= $2 THEN GREATEST(items.price, nfts_with_orders.max_price) ELSE nfts_with_orders.max_price END AS max_price`
+        )
         expect(query).not.toContain(`AND orders.price >= $`)
         expect(query.values.includes(maxPrice)).toBe(true)
       })

--- a/src/tests/ports/catalog-queries.spec.ts
+++ b/src/tests/ports/catalog-queries.spec.ts
@@ -425,7 +425,7 @@ test('catalog utils', () => {
         const queryTextFormatted = query.text.replace(/\s+/g, ' ')
         expect(query.text).toContain(`AND orders.price <= $`)
         expect(queryTextFormatted).toContain(
-          `CASE WHEN available > 0 AND items.search_is_store_minter = true AND items.price <= $2 THEN GREATEST(items.price, nfts_with_orders.max_price) ELSE nfts_with_orders.max_price END AS max_price`
+          `CASE WHEN items.available > 0 AND items.search_is_store_minter = true AND items.price <= $2 THEN GREATEST(items.price, nfts_with_orders.max_price) ELSE nfts_with_orders.max_price END AS max_price`
         )
         expect(query).not.toContain(`AND orders.price >= $`)
         expect(query.values.includes(maxPrice)).toBe(true)


### PR DESCRIPTION
This PR adds the price filter in the `min_price` and `max_price` `CASE` statements where they are defined. This is needed so they are sorted in the correct order at the end of the query.