### PR TITLE
fix: owners query not using the right index for contract_address

### DIFF
--- a/src/ports/owner/utils.ts
+++ b/src/ports/owner/utils.ts
@@ -24,7 +24,7 @@ export const getOwnersSQLQuery = (
 
   const where = [
     contractAddress
-      ? SQL`left(contract_address, 256) = ${contractAddress}`
+      ? SQL`left(nfts.contract_address, 256) = ${contractAddress}`
       : undefined,
     itemId ? SQL`nfts.item_blockchain_id = ${itemId}` : undefined,
   ].filter(Boolean)

--- a/src/ports/owner/utils.ts
+++ b/src/ports/owner/utils.ts
@@ -24,7 +24,7 @@ export const getOwnersSQLQuery = (
 
   const where = [
     contractAddress
-      ? SQL`nfts.contract_address = ${contractAddress}`
+      ? SQL`left(contract_address, 256) = ${contractAddress}`
       : undefined,
     itemId ? SQL`nfts.item_blockchain_id = ${itemId}` : undefined,
   ].filter(Boolean)


### PR DESCRIPTION
the index is created on `left(contract_address, 256)`. Most probably to save disk space, so we need to explicity filter against it.