### PR TITLE
fix: remove unnecessary client.release()

### DIFF
--- a/src/ports/catalog/component.ts
+++ b/src/ports/catalog/component.ts
@@ -70,7 +70,6 @@ export function createCatalogComponent(options: {
           )
           if (filteredItemsById.rowCount === 0) {
             // if no items matched the search text, return empty result
-            client.release()
             return { data: [], total: 0 }
           }
           filters.ids = [


### PR DESCRIPTION
The `client.release()` removed in this PR is unnecessary since it's executed in the `finally` [here](https://github.com/decentraland/nft-server/pull/306/files#diff-266d78ef6bf1741665662502c979d2ad238b72aca682e549cdb2402950c1a813L105)