### PR TITLE
fix: prices fetch with wearablecategory hands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ import {
   getCollectionsOrderBy,
 } from './logic/nfts/collections'
 import {
+  getMarketplacePriceFiltersValidation,
   getMarketplacePricesQuery,
   marketplaceShouldFetch as marketplaceShouldFetchPrices,
 } from './logic/prices/marketplace'
@@ -599,6 +600,7 @@ async function initComponents(): Promise<AppComponents> {
   const marketplacePrices = createPricesComponent({
     subgraph: marketplaceSubgraph,
     queryGetter: getMarketplacePricesQuery,
+    customValidation: getMarketplacePriceFiltersValidation,
   })
 
   const collectionsPrices = createPricesComponent({

--- a/src/logic/prices/marketplace.ts
+++ b/src/logic/prices/marketplace.ts
@@ -1,4 +1,9 @@
-import { Network, NFTCategory, NFTFilters } from '@dcl/schemas'
+import {
+  Network,
+  NFTCategory,
+  NFTFilters,
+  WearableCategory,
+} from '@dcl/schemas'
 import {
   addLandFilters,
   addWearableCategoryAndRaritiesFilters,
@@ -45,6 +50,14 @@ export const getNFTCategoryFromPriceCategory = (
     default:
       return [category]
   }
+}
+
+export const getMarketplacePriceFiltersValidation = (filters: PriceFilters) => {
+  const { wearableCategory } = filters
+  // There aren't any HANDS_WEAR wearables in the marketplace subgraph as its only available
+  // for new versions of wearables. If the wearableCategory filter is hands_wear we shouldn't
+  // fetch marketplace graph
+  return wearableCategory !== WearableCategory.HANDS_WEAR
 }
 
 export function getMarketplacePricesQuery(id: string) {

--- a/src/ports/prices/component.ts
+++ b/src/ports/prices/component.ts
@@ -14,12 +14,13 @@ import { consolidatePrices, getPricesQuery, MAX_RESULTS } from './utils'
 
 export function createPricesComponent(options: {
   subgraph: ISubgraphComponent
+  customValidation?: (filters: PriceFilters) => boolean
   queryGetter: (
     id: string,
     filters: PriceFilters
   ) => (filters: PriceFilters) => string
 }): IPricesComponent {
-  const { subgraph, queryGetter } = options
+  const { subgraph, queryGetter, customValidation } = options
 
   function isValid(filters: PriceFilters) {
     const { category, assetType } = filters
@@ -33,7 +34,7 @@ export function createPricesComponent(options: {
   }
 
   async function fetch(filters: PriceFilters) {
-    if (!isValid(filters)) {
+    if (!isValid(filters) || (customValidation && !customValidation(filters))) {
       return []
     }
 

--- a/src/tests/components.ts
+++ b/src/tests/components.ts
@@ -128,6 +128,7 @@ import {
   collectionsShouldFetch as collectionsShouldFetchPrices,
 } from '../logic/prices/collections'
 import {
+  getMarketplacePriceFiltersValidation,
   getMarketplacePricesQuery,
   marketplaceShouldFetch as marketplaceShouldFetchPrices,
 } from '../logic/prices/marketplace'
@@ -578,6 +579,7 @@ export async function initComponents(): Promise<AppComponents> {
   const marketplacePrices = createPricesComponent({
     subgraph: marketplaceSubgraph,
     queryGetter: getMarketplacePricesQuery,
+    customValidation: getMarketplacePriceFiltersValidation
   })
 
   const collectionsPrices = createPricesComponent({

--- a/src/tests/ports/prices.spec.ts
+++ b/src/tests/ports/prices.spec.ts
@@ -106,4 +106,25 @@ describe('when getting prices', () => {
       ).rejects.toThrowError(error)
     })
   })
+
+  describe('and price component custom validation returns false', () => {
+    beforeEach(() => {
+      collectionsPriceComponent = createPricesComponent({
+        subgraph: collectionsSubgraph,
+        queryGetter: getCollectionPricesQuery,
+        customValidation: () => false
+      })
+    })
+
+    it('should retrurn empty array as a result', () => {
+      return expect(
+        collectionsPriceComponent.fetch(filters)
+      ).resolves.toEqual([])
+    })
+
+    it('should not have called the get query method', () => {
+      expect(collectionsSubgraphQueryMock).not.toHaveBeenCalled()
+    })
+  })
 })
+


### PR DESCRIPTION
Marketplace graph doesn't have this new category as it will only be included in new wearables (that are in the collections graph). This pr adds a new validation for the priceComponent for marketplace graph so that it doesn't fetch if the wearableCategory filter is `hands_wear`