### PR TITLE
fix: do not call marketplace graph when category hands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import {
   fromMarketplaceNFTFragment,
   getMarketplaceExtraVariables,
   getMarketplaceExtraWhere,
+  getMarketplaceFiltersValidation,
   getMarketplaceFragment,
   getMarketplaceOrderBy,
   marketplaceShouldFetch,
@@ -360,6 +361,7 @@ async function initComponents(): Promise<AppComponents> {
     getSortByProp: getMarketplaceOrderBy,
     getExtraVariables: getMarketplaceExtraVariables,
     getExtraWhere: getMarketplaceExtraWhere,
+    getShouldFetch: getMarketplaceFiltersValidation
   })
 
   const collectionsNFTs = createNFTComponent({

--- a/src/logic/nfts/marketplace.ts
+++ b/src/logic/nfts/marketplace.ts
@@ -154,6 +154,14 @@ export function getMarketplaceOrderBy(
   }
 }
 
+export const getMarketplaceFiltersValidation = (filters: NFTFilters) => {
+  const { wearableCategory } = filters
+  // There aren't any HANDS_WEAR wearables in the marketplace subgraph as its only available
+  // for new versions of wearables. If the wearableCategory filter is hands_wear we shouldn't
+  // fetch marketplace graph
+  return wearableCategory !== WearableCategory.HANDS_WEAR
+}
+
 export function fromMarketplaceNFTFragment(
   fragment: MarketplaceNFTFragment
 ): NFTResult {

--- a/src/ports/nfts/component.ts
+++ b/src/ports/nfts/component.ts
@@ -16,6 +16,7 @@ export function createNFTComponent<T extends { id: string }>(options: {
   getSortByProp(sortBy?: NFTSortBy): keyof T
   getExtraVariables?: (options: NFTFilters) => string[]
   getExtraWhere?: (options: NFTFilters) => string[]
+  getShouldFetch?: (options: NFTFilters) => boolean 
 }): INFTsComponent {
   const {
     subgraph,
@@ -25,6 +26,7 @@ export function createNFTComponent<T extends { id: string }>(options: {
     getExtraWhere,
     getExtraVariables,
     fromFragment,
+    getShouldFetch,
   } = options
 
   function getFragmentFetcher(filters: NFTFilters) {
@@ -46,6 +48,9 @@ export function createNFTComponent<T extends { id: string }>(options: {
   }
 
   async function fetch(options: NFTFilters): Promise<NFTResult[]> {
+    if (getShouldFetch && !getShouldFetch(options)) {
+      return []
+    }
     if (
       options.tokenId &&
       options.contractAddresses &&
@@ -66,6 +71,9 @@ export function createNFTComponent<T extends { id: string }>(options: {
   }
 
   async function count(options: NFTFilters): Promise<number> {
+    if (getShouldFetch && !getShouldFetch(options)) {
+      return 0
+    }
     const fetchFragments = getFragmentFetcher(options)
     const fragments = await fetchFragments(true)
     return fragments.length


### PR DESCRIPTION
Fix error when fetching nfts with category hands. It should not fetch marketplace graph as the category doesn't exist in old wearables