### PR TITLE
fix: Expiration of orders in seconds

### DIFF
--- a/src/logic/expiration.ts
+++ b/src/logic/expiration.ts
@@ -1,3 +1,3 @@
 export function isExpired(expiresAt: string) {
-  return +expiresAt < Date.now()
+  return BigInt(expiresAt) * 1000n < Date.now()
 }

--- a/src/logic/expiration.ts
+++ b/src/logic/expiration.ts
@@ -1,3 +1,7 @@
 export function isExpired(expiresAt: string) {
+  return +expiresAt < Date.now()
+}
+
+export function isOrderExpired(expiresAt: string) {
   return BigInt(expiresAt) * 1000n < Date.now()
 }

--- a/src/logic/nfts/collections.ts
+++ b/src/logic/nfts/collections.ts
@@ -19,7 +19,7 @@ import {
   getCollectionsOrderFields,
 } from '../../ports/orders/utils'
 import { getCollectionsChainId } from '../chainIds'
-import { isExpired } from '../expiration'
+import { isOrderExpired } from '../expiration'
 
 export const getCollectionsFields = () => `
   fragment collectionsFields on NFT {
@@ -192,7 +192,7 @@ export function fromCollectionsFragment(
       contractAddress: fragment.contractAddress,
       category,
       activeOrderId:
-        fragment.activeOrder && !isExpired(fragment.activeOrder.expiresAt)
+        fragment.activeOrder && !isOrderExpired(fragment.activeOrder.expiresAt)
           ? fragment.activeOrder.id
           : null,
       openRentalId: null,
@@ -211,7 +211,7 @@ export function fromCollectionsFragment(
       soldAt: +fragment.soldAt * 1000,
     },
     order:
-      fragment.activeOrder && !isExpired(fragment.activeOrder.expiresAt)
+      fragment.activeOrder && !isOrderExpired(fragment.activeOrder.expiresAt)
         ? fromCollectionsOrderFragment(fragment.activeOrder)
         : null,
     rental: null,

--- a/src/logic/nfts/marketplace.spec.ts
+++ b/src/logic/nfts/marketplace.spec.ts
@@ -151,7 +151,7 @@ describe('when building a result from the marketplace fragment', () => {
     describe('and the order is not expired', () => {
       beforeEach(() => {
         marketplaceFragment.activeOrder!.expiresAt = Math.floor(
-          (Date.now() + 60 * 1000 * 60) / 1000
+          Date.now() + 60 * 1000 * 60
         ).toString()
       })
 

--- a/src/ports/orders/utils.ts
+++ b/src/ports/orders/utils.ts
@@ -122,7 +122,7 @@ export const getOrdersQuery = (
 
   if (status) {
     if (status === ListingStatus.OPEN) {
-      where.push(`expiresAt_gt: "${Date.now()}"`)
+      where.push(`expiresAt_gt: "${Math.round(Date.now() / 1000)}"`)
     }
     where.push(`status: ${status}`)
   }


### PR DESCRIPTION
The expiration of orders were computed in milliseconds instead of seconds. This PR changes it so orders don't get expired.