### PR TITLE
fix: main catalog query sort when filtering by text

### DIFF
--- a/src/adapters/handlers/catalog.ts
+++ b/src/adapters/handlers/catalog.ts
@@ -16,9 +16,7 @@ export function createCatalogHandler(
     const params = new Params(context.url.searchParams)
     const onlyListing = params.getBoolean('onlyListing')
     const onlyMinting = params.getBoolean('onlyMinting')
-    const sortBy =
-      params.getValue<CatalogSortBy>('sortBy', CatalogSortBy) ||
-      CatalogSortBy.CHEAPEST
+    const sortBy = params.getValue<CatalogSortBy>('sortBy', CatalogSortBy)
     const sortDirection =
       params.getValue<CatalogSortDirection>(
         'sortDirection',

--- a/src/ports/catalog/component.ts
+++ b/src/ports/catalog/component.ts
@@ -60,6 +60,7 @@ export function createCatalogComponent(options: {
           ]
         }
 
+        filters.search = undefined // resets the search text since it's already filtered by the query
         if (filters.ids?.length === 0) {
           // if no items matched the search text, return empty result
           return { data: [], total: 0 }

--- a/src/ports/catalog/component.ts
+++ b/src/ports/catalog/component.ts
@@ -60,7 +60,6 @@ export function createCatalogComponent(options: {
           ]
         }
 
-        filters.search = undefined // resets the search text since it's already filtered by the query
         if (filters.ids?.length === 0) {
           // if no items matched the search text, return empty result
           return { data: [], total: 0 }

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -21,7 +21,7 @@ const WEARABLE_ITEM_TYPES = [
 const MAX_ORDER_TIMESTAMP = 253378408747000 // some orders have a timestmap that can't be cast by Postgres, this is the max possible value
 
 export function getOrderBy(filters: CatalogFilters) {
-  const { sortBy, sortDirection, isOnSale, search } = filters
+  const { sortBy, sortDirection, isOnSale, search, ids } = filters
   const sortByParam = sortBy ?? CatalogSortBy.NEWEST
   const sortDirectionParam = sortDirection ?? CatalogSortDirection.DESC
 
@@ -30,8 +30,9 @@ export function getOrderBy(filters: CatalogFilters) {
     return ''
   }
 
-  if (search) {
-    // If the filters have a search term, we need to order by the position of the item in the search results that is pre-computed and passed in the ids filter.
+  if (search && !sortBy && ids?.length) {
+    // If the filters have a search term, there's no other Sort applied and ids matching the search were returned, then
+    // we need to order by the position of the item in the search results that is pre-computed and passed in the ids filter.
     return SQL`ORDER BY array_position(${filters.ids}::text[], id) `
   }
 

--- a/src/ports/catalog/utils.ts
+++ b/src/ports/catalog/utils.ts
@@ -20,7 +20,7 @@ import {
   CatalogQueryFilters,
   CollectionsItemDBResult,
 } from './types'
-import { addQuerySort, getCollectionsItemsCatalogQuery } from './queries'
+import { getCollectionsItemsCatalogQuery, getOrderBy } from './queries'
 
 const getMultiNetworkQuery = (
   schemas: Record<string, string>,
@@ -43,7 +43,7 @@ const getMultiNetworkQuery = (
     }
   })
   unionQuery.append(SQL`\n) as temp \n`)
-  addQuerySort(unionQuery, filters)
+  unionQuery.append(getOrderBy(filters))
   if (limit !== undefined && offset !== undefined) {
     unionQuery.append(SQL`LIMIT ${limit} OFFSET ${offset}`)
   }
@@ -101,7 +101,7 @@ export function fromCollectionsItemDbResultToCatalogItem(
         loop,
         category: emoteCategory,
         has_sound,
-        has_geometry
+        has_geometry,
       } = dbItem.metadata
       ;(name = emoteName), (category = NFTCategory.EMOTE)
       data = {
@@ -112,7 +112,7 @@ export function fromCollectionsItemDbResultToCatalogItem(
           rarity: rarity as Rarity,
           loop: !!loop,
           hasSound: !!has_sound,
-          hasGeometry: !!has_geometry
+          hasGeometry: !!has_geometry,
         },
       }
       break

--- a/src/tests/ports/catalog.spec.ts
+++ b/src/tests/ports/catalog.spec.ts
@@ -314,8 +314,7 @@ test('catalog component', function () {
           })
         })
         it('should return an empty array and a total count of 0', async () => {
-          // destructuring filters here since the `fetch` logic will reset the search so it's not used in the main `getCatalogQuery` query
-          expect(await catalogComponent.fetch({ ...filters })).toEqual({
+          expect(await catalogComponent.fetch(filters)).toEqual({
             data: [],
             total: 0,
           })
@@ -362,8 +361,7 @@ test('catalog component', function () {
           })
         })
         it('should use the ids returned by the search query in the main catalog query and be sorted by them', async () => {
-          // destructuring filters here since the `fetch` logic will reset the search so it's not used in the main `getCatalogQuery` query
-          expect(await catalogComponent.fetch({ ...filters })).toEqual({
+          expect(await catalogComponent.fetch(filters)).toEqual({
             data: [
               {
                 ...fromCollectionsItemDbResultToCatalogItem(


### PR DESCRIPTION
The main query should have the `filter.search` param cleaned so it doesn't sort by relevance. (It will sort by relevance if no other sort is used).