### PR TITLE
feat: add limit & offset to the catalog search pre-query

### DIFF
--- a/src/ports/catalog/component.ts
+++ b/src/ports/catalog/component.ts
@@ -48,11 +48,7 @@ export function createCatalogComponent(options: {
       if (filters.search) {
         for (const schema of Object.values(reducedSchemas)) {
           const filteredItemsById = await client.query<CollectionsItemDBResult>(
-            getItemIdsBySearchTextQuery(
-              schema,
-              filters.search,
-              filters.category
-            )
+            getItemIdsBySearchTextQuery(schema, filters)
           )
           filters.ids = [
             ...(filters.ids ?? []),

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -456,9 +456,9 @@ export const getCollectionsItemsCatalogQuery = (
 
 export const getItemIdsBySearchTextQuery = (
   schemaVersion: string,
-  search: CatalogQueryFilters['search'],
-  category: CatalogQueryFilters['category']
+  filters: CatalogQueryFilters
 ) => {
+  const { category, search, limit, offset } = filters
   const query = SQL`SELECT items.id`
     .append(` FROM `)
     .append(schemaVersion)
@@ -469,9 +469,10 @@ export const getItemIdsBySearchTextQuery = (
     .append(getSearchWhere({ search, category }))
     .append(
       category
-        ? SQL` ORDER BY GREATEST(similarity(word, ${search})) DESC;`
-        : SQL` ORDER BY GREATEST(similarity(word_wearable, ${search}), similarity(word_emote, ${search})) DESC;`
+        ? SQL` ORDER BY GREATEST(similarity(word, ${search})) DESC`
+        : SQL` ORDER BY GREATEST(similarity(word_wearable, ${search}), similarity(word_emote, ${search})) DESC`
     )
+    .append(SQL` LIMIT ${limit} OFFSET ${offset};`)
 
   return query
 }

--- a/src/tests/ports/catalog.spec.ts
+++ b/src/tests/ports/catalog.spec.ts
@@ -285,16 +285,20 @@ test('catalog component', function () {
       let pickStats: PickStats
       let network = Network.ETHEREUM
       let filters: CatalogFilters
+      let limit: number, offset: number
       let latestSchema = 'sgd1234'
       let search: string
 
       beforeEach(() => {
         search = 'aSearchTerm'
+        limit = 10
+        offset = 0
         filters = {
           network,
           search,
+          limit,
+          offset,
         }
-
         latestSubgraphSchemaResponse = {
           rows: [
             {
@@ -326,16 +330,17 @@ test('catalog component', function () {
           )
           const itemIdsBySearchTextQuery = getItemIdsBySearchTextQuery(
             latestSchema,
-            filters.search,
-            filters.category
+            filters
           )
           expect(dbClientQueryMock.mock.calls[1][0]).toEqual(
             itemIdsBySearchTextQuery
           )
           // It's repeated 4 times due to this WHERE statement: `WHERE word_wearable % $1 OR word_emote % $2 ORDER BY GREATEST(similarity(word_wearable, $3), similarity(word_emote, $4)) DESC;`
-          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual(
-            Array(4).fill(search)
-          )
+          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual([
+            ...Array(4).fill(search),
+            limit,
+            offset,
+          ])
         })
       })
 
@@ -379,16 +384,14 @@ test('catalog component', function () {
             )
           )
           expect(dbClientQueryMock.mock.calls[1][0]).toEqual(
-            getItemIdsBySearchTextQuery(
-              latestSchema,
-              filters.search,
-              filters.category
-            )
+            getItemIdsBySearchTextQuery(latestSchema, filters)
           )
           // It's repeated 4 times due to this WHERE statement: `WHERE word_wearable % $1 OR word_emote % $2 ORDER BY GREATEST(similarity(word_wearable, $3), similarity(word_emote, $4)) DESC;`
-          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual(
-            Array(4).fill(search)
-          )
+          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual([
+            ...Array(4).fill(search),
+            limit,
+            offset,
+          ])
           const mainCatalogQuery = getCatalogQuery(
             { [network]: latestSchema },
             { ...filters, ids: [mockedDBItemResponse.id] } // the main query should have the ids returned by the search query


### PR DESCRIPTION
The query was missing the LIMIT & OFFSET parameters so it might have been bringing a lot of results and using a lot of memory.