### PR TITLE
fix: catalog search ignore limit and offset

### DIFF
--- a/src/logic/nfts/marketplace.spec.ts
+++ b/src/logic/nfts/marketplace.spec.ts
@@ -138,7 +138,6 @@ describe('when building a result from the marketplace fragment', () => {
       })
 
       it('should not contain an order', () => {
-        console.log(fromMarketplaceNFTFragment(marketplaceFragment).nft)
         expect(fromMarketplaceNFTFragment(marketplaceFragment)).toMatchObject({
           nft: {
             activeOrderId: null,

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -458,7 +458,7 @@ export const getItemIdsBySearchTextQuery = (
   schemaVersion: string,
   filters: CatalogQueryFilters
 ) => {
-  const { category, search, limit, offset } = filters
+  const { category, search } = filters
   const query = SQL`SELECT 
       items.id, 
       GREATEST(similarity(word, ${search}), similarity(metadata_wearable.name, ${search}), 
@@ -473,9 +473,8 @@ export const getItemIdsBySearchTextQuery = (
     .append(
       category
         ? SQL` ORDER BY GREATEST(similarity(word, ${search}), similarity(metadata_wearable.name, ${search}), similarity(metadata_emote.name, ${search})) DESC`
-        : SQL` ORDER BY GREATEST(similarity(word_wearable, ${search}), similarity(word_emote, ${search})) DESC`
+        : SQL` ORDER BY GREATEST(similarity(word_wearable, ${search}), similarity(word_emote, ${search})) DESC;`
     )
-    .append(SQL` LIMIT ${limit} OFFSET ${offset};`)
 
   return query
 }

--- a/src/tests/ports/catalog-queries.spec.ts
+++ b/src/tests/ports/catalog-queries.spec.ts
@@ -528,11 +528,7 @@ test('catalog utils', () => {
           )
           expect(query.text).toContain(`word_wearable % $4 OR word_emote % $5 `)
           // it appears four times `JOIN LATERAL unnest(string_to_array(metadata_emote.name, ' ')) AS word ON TRUE WHERE word % $1 ORDER BY GREATEST(similarity(word, $2))`
-          expect(query.values).toStrictEqual([
-            ...Array(7).fill(search),
-            limit,
-            offset,
-          ])
+          expect(query.values).toStrictEqual(Array(7).fill(search))
         })
       })
 
@@ -552,11 +548,7 @@ test('catalog utils', () => {
           )
           expect(query.text).toContain(`word % $4 `)
           // it appears twice `JOIN LATERAL unnest(string_to_array(metadata_wearable.name, ' ')) AS word ON TRUE WHERE word % $1 ORDER BY GREATEST(similarity(word, $2))`
-          expect(query.values).toStrictEqual([
-            ...Array(7).fill(search),
-            limit,
-            offset,
-          ])
+          expect(query.values).toStrictEqual(Array(7).fill(search))
         })
       })
 
@@ -576,12 +568,20 @@ test('catalog utils', () => {
           )
           expect(query.text).toContain(`word % $4 `)
           // it appears twice `JOIN LATERAL unnest(string_to_array(metadata_emote.name, ' ')) AS word ON TRUE WHERE word % $1 ORDER BY GREATEST(similarity(word, $2), similarity(metadata_wearable.name, $3), similarity(metadata_emote.name, $4))`
-          expect(query.values).toStrictEqual([
-            ...Array(7).fill(search),
-            limit,
-            offset,
-          ])
+          expect(query.values).toStrictEqual(Array(7).fill(search))
         })
+      })
+
+      it('should search for all ids without limit', () => {
+        const query = getItemIdsBySearchTextQuery(schema, {
+          search,
+          category,
+          limit,
+          offset,
+        })
+
+        expect(query.text).not.toContain('LIMIT')
+        expect(query.text).not.toContain('OFFSET')
       })
     })
   })

--- a/src/tests/ports/catalog.spec.ts
+++ b/src/tests/ports/catalog.spec.ts
@@ -336,11 +336,7 @@ test('catalog component', function () {
             itemIdsBySearchTextQuery
           )
           // It's repeated 7 times due to the SELECT + WHERE statements: `WHERE word_wearable % $1 OR word_emote % $2 ORDER BY GREATEST(similarity(word_wearable, $3), similarity(word_emote, $4)) DESC;`
-          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual([
-            ...Array(7).fill(search),
-            limit,
-            offset,
-          ])
+          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual(Array(7).fill(search))
         })
       })
 
@@ -387,11 +383,7 @@ test('catalog component', function () {
             getItemIdsBySearchTextQuery(latestSchema, filters)
           )
           // It's repeated 4 times due to this WHERE statement: `WHERE word_wearable % $1 OR word_emote % $2 ORDER BY GREATEST(similarity(word_wearable, $3), similarity(word_emote, $4)) DESC;`
-          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual([
-            ...Array(7).fill(search),
-            limit,
-            offset,
-          ])
+          expect(dbClientQueryMock.mock.calls[1][0].values).toEqual(Array(7).fill(search))
           const mainCatalogQuery = getCatalogQuery(
             { [network]: latestSchema },
             { ...filters, ids: [mockedDBItemResponse.id] } // the main query should have the ids returned by the search query


### PR DESCRIPTION
When searching for items in the catalog by a search term we should not limit the query that search for ids with specific term as it will cause for some items to be filtered before doing the proper catalog search

before this change
`/v1/catalog?first=5&category=wearable&search=m` would return only one item as it will only consider the first 5 ids that match the term m to later do the wearable category filter

after this change
`/v1/catalog?first=5&category=wearable&search=m` will return 5 (with the total being 81)