### PR TITLE
feat: add some params validation for items endpoint

### DIFF
--- a/src/adapters/handlers/items.ts
+++ b/src/adapters/handlers/items.ts
@@ -4,6 +4,11 @@ import { AppComponents, AuthenticatedContext } from '../../types'
 import { Params } from '../../logic/http/params'
 import { HttpError, asJSON } from '../../logic/http/response'
 import { getItemsParams } from './utils'
+import {
+  validateItemsParams,
+  InvalidContractAddressError,
+  InvalidItemIdError,
+} from '../../logic/items/utils'
 
 export function createItemsHandler(
   components: Pick<AppComponents, 'items'>
@@ -28,6 +33,19 @@ export function createItemsHandler(
           'Ids cannot be set with contractAddress, itemId, or urn.',
           400
         )
+      }
+
+      try {
+        // Validate contract addresses and itemId
+        validateItemsParams(contractAddresses || [], itemId)
+      } catch (error) {
+        if (
+          error instanceof InvalidContractAddressError ||
+          error instanceof InvalidItemIdError
+        ) {
+          throw new HttpError(error.message, 400)
+        }
+        throw error // Rethrow if it's another type of error
       }
 
       return items.fetchAndCount({

--- a/src/logic/items/utils.ts
+++ b/src/logic/items/utils.ts
@@ -1,5 +1,21 @@
 import { Item, ItemSortBy } from '@dcl/schemas'
 import { Sortable } from '../../ports/merger/types'
+import { isAddress } from '../../logic/address'
+
+// Custom error classes for validation errors
+export class InvalidContractAddressError extends Error {
+  constructor(address: string) {
+    super(`Invalid contract address: ${address}`)
+    this.name = 'InvalidContractAddressError'
+  }
+}
+
+export class InvalidItemIdError extends Error {
+  constructor() {
+    super('Invalid itemId, must be a valid BigInt')
+    this.name = 'InvalidItemIdError'
+  }
+}
 
 export function convertItemToSortableResult(
   result: Item
@@ -14,5 +30,34 @@ export function convertItemToSortableResult(
       [ItemSortBy.CHEAPEST]: result.available > 0 ? +result.price : null,
       [ItemSortBy.RECENTLY_LISTED]: result.firstListedAt,
     },
+  }
+}
+
+/**
+ * Validates the contract addresses and itemId parameters for item-related queries
+ * @param contractAddresses Array of contract addresses to validate
+ * @param itemId The itemId to validate if any
+ * @throws InvalidContractAddressError or InvalidItemIdError if validation fails
+ */
+export function validateItemsParams(
+  contractAddresses: string[],
+  itemId?: string | null
+): void {
+  // Validate contract addresses if any
+  if (contractAddresses.length > 0) {
+    for (const address of contractAddresses) {
+      if (!isAddress(address)) {
+        throw new InvalidContractAddressError(address)
+      }
+    }
+  }
+
+  // Validate itemId if any
+  if (itemId) {
+    try {
+      BigInt(itemId)
+    } catch (error) {
+      throw new InvalidItemIdError()
+    }
   }
 }

--- a/src/tests/logic/items/utils.spec.ts
+++ b/src/tests/logic/items/utils.spec.ts
@@ -1,0 +1,85 @@
+import {
+  validateItemsParams,
+  InvalidContractAddressError,
+  InvalidItemIdError,
+} from '../../../logic/items/utils'
+import { isAddress } from '../../../logic/address'
+
+jest.mock('../../../logic/address', () => ({
+  isAddress: jest.fn(),
+}))
+
+describe('validateItemsParams', () => {
+  const isAddressMock = isAddress as jest.Mock
+
+  beforeEach(() => {
+    isAddressMock.mockReset()
+    isAddressMock.mockImplementation((address) =>
+      /^0x[a-fA-F0-9]{40}$/.test(address)
+    )
+  })
+
+  describe('when validating contract addresses', () => {
+    it('should do nothing with valid addresses', () => {
+      const validAddress = '0x1234567890123456789012345678901234567890'
+      expect(() => validateItemsParams([validAddress])).not.toThrow()
+    })
+
+    it('should throw InvalidContractAddressError for invalid addresses', () => {
+      const invalidAddress = '0xinvalid'
+      expect(() => validateItemsParams([invalidAddress])).toThrow(
+        new InvalidContractAddressError(invalidAddress)
+      )
+    })
+
+    it('should validate multiple addresses', () => {
+      const validAddress = '0x1234567890123456789012345678901234567890'
+      const invalidAddress = '0xinvalid'
+      expect(() => validateItemsParams([validAddress, invalidAddress])).toThrow(
+        new InvalidContractAddressError(invalidAddress)
+      )
+    })
+
+    it('should not throw for empty addresses array', () => {
+      expect(() => validateItemsParams([])).not.toThrow()
+    })
+  })
+
+  describe('when validating itemId', () => {
+    it('should do nothing with valid BigInt itemId', () => {
+      expect(() => validateItemsParams([], '123')).not.toThrow()
+    })
+
+    it('should throw InvalidItemIdError for non-BigInt values', () => {
+      expect(() => validateItemsParams([], 'notABigInt')).toThrow(
+        new InvalidItemIdError()
+      )
+    })
+
+    it('should not throw for undefined or null itemId', () => {
+      expect(() => validateItemsParams([], undefined)).not.toThrow()
+      expect(() => validateItemsParams([], null)).not.toThrow()
+    })
+  })
+
+  describe('when validating both parameters', () => {
+    it('should throw InvalidContractAddressError for invalid address even with valid itemId', () => {
+      const invalidAddress = '0xinvalid'
+      expect(() => validateItemsParams([invalidAddress], '123')).toThrow(
+        new InvalidContractAddressError(invalidAddress)
+      )
+    })
+
+    it('should throw InvalidItemIdError for invalid itemId even with valid address', () => {
+      const validAddress = '0x1234567890123456789012345678901234567890'
+      expect(() => validateItemsParams([validAddress], 'notABigInt')).toThrow(
+        new InvalidItemIdError()
+      )
+    })
+
+    it('should validate successfully when both parameters are valid', () => {
+      const validAddress = '0x1234567890123456789012345678901234567890'
+      expect(() => validateItemsParams([validAddress], '123')).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Contract Address and ItemId Validation

### Overview
Added validation for contract addresses and itemIds in the items handler to catch invalid inputs before they reach the subgraph, preventing unnecessary queries and providing clearer error messages to clients.

### Changes
- Added `validateItemsParams` function to validate contract addresses and itemIds
- Created specific error classes (`InvalidContractAddressError` and `InvalidItemIdError`) for better error handling
- Modified the items handler to catch these errors and return appropriate HTTP 400 responses
- Added comprehensive test coverage for both the validation logic and error handling

### Benefits
- Prevents invalid Ethereum addresses from being sent to the subgraph
- Catches non-BigInt itemIds early, providing clear error messages
- Improves error handling and user experience
- Reduces unnecessary load on the subgraph services